### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: setup-android
-        uses: msfjarvis/setup-android@0.2
-        with:
-          # Gradle tasks to run - If you want to run ./gradlew assemble, specify assemble here.
-          gradleTasks: build -x mirai-core:jvmTest
+        run: ./gradlew build -x mirai-core:jvmTest
 


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.﻿