### PR TITLE
暂时解决mirai半身像

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-   <img width="160" src="http://img.mamoe.net/2020/02/16/a759783b42f72.png" alt="logo"></br>
+   <img width="160" src="https://tva1.sinaimg.cn/large/007kOCb2ly1ges6us0aqyj30u00u0tdq.jpg" alt="logo"></br>
 
 
    <img width="95" src="http://img.mamoe.net/2020/02/16/c4aece361224d.png" alt="title">


### PR DESCRIPTION
国内对camo的谜之操作导致不小一部分用户访问时图像只有上半身
因为没有mamoe图床的上传权限，所以将图片换至sina的图床(虽然也会被预取到camo)但是看起来修复了

如果可以的话请试试附件的png，也许文件指纹变动即可让camo刷新缓存解决问题
[(附件上传失败](https://t.imlxy.net/m.png)