### PR TITLE
新的社区 SDK：mirai-ts (TypeScript/JavaScript)

### DIFF
--- a/README-eng.md
+++ b/README-eng.md
@@ -33,6 +33,7 @@ Mirai is building a community (with `mirai-console`) that allows developers to s
 - （Community）`C++`: [mirai-cpp](https://github.com/cyanray/mirai-cpp) A simple C++ SDK using `mirai-api-http` for ALL platforms.
 - （Community）`C++`: [miraipp](https://github.com/Chlorie/miraipp-template) A sophisticated, modern mapping for `mirai-http-api` to C++, providing development documents.
 - （Community）`Rust`: [mirai-rs](https://github.com/HoshinoTented/mirai-rs) The Rust mapping for `mirai-http-api`.
+- （Community）`TypeScropt`: [mirai-ts](https://github.com/YunYouJun/mirai-ts) TypeScript SDK comes with a declaration file, has good code hints, and can also be used as a JavaScript SDK.
 
 ### Use as a library
 You can install mirai as a library into your project.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ mirai 既可以作为项目中的 QQ 协议支持库, 也可以作为单独的�
 - `C++`: [miraipp](https://github.com/Chlorie/miraipp-template) mirai-http-api 的另一个 C++ 封装，使用现代 C++ 特性，并提供了较完善的说明文档
 - `C#`: [Mirai-CSharp](https://github.com/Executor-Cheng/Mirai-CSharp) 基于 mirai-api-http 的 C# SDK
 - `Rust`: [mirai-rs](https://github.com/HoshinoTented/mirai-rs) mirai-http-api 的 Rust 封装
+- `TypeScropt`: [mirai-ts](https://github.com/YunYouJun/mirai-ts) mirai-api-http 的 TypeScript SDK，附带声明文件，拥有良好的注释和类型提示，也可作为 JavaScript SDK 使用。
 
 </details>
 


### PR DESCRIPTION
[mirai-ts](https://github.com/YunYouJun/mirai-ts) 是基于 mirai-api-http 的 TypeScript SDK，亦可作为 JavaScript SDK 使用，已发布 npm 包 [mirai-ts](https://www.npmjs.com/package/mirai-ts)。
附带声明文件，因此使用时可以有友好的注释及类型提示。
mirai-api-http 的 API 以及 WebSocket 已经全部支持，并有示例机器人 [el-bot-js](https://github.com/ElpsyCN/el-bot-js/)。