### PR TITLE
修复成员进群后第一次发言触发改名事件

### DIFF
--- a/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/network/protocol/packet/chat/receive/MessageSvc.PbGetMsg.kt
+++ b/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/network/protocol/packet/chat/receive/MessageSvc.PbGetMsg.kt
@@ -110,7 +110,8 @@ internal object MessageSvcPbGetMsg : OutgoingPacketFactory<MessageSvcPbGetMsg.Re
 
     private fun MsgComm.Msg.getNewMemberInfo(): MemberInfo {
         return object : MemberInfo {
-            override val nameCard: String get() = ""
+            override val nameCard: String get() = msgHead.authNick.takeIf { it.isNotEmpty() }
+                ?: msgHead.fromNick
             override val permission: MemberPermission get() = MemberPermission.MEMBER
             override val specialTitle: String get() = ""
             override val muteTimestamp: Int get() = 0

--- a/mirai-serialization/src/commonMain/kotlin/net/mamoe/mirai/message/code/internal/impl.kt
+++ b/mirai-serialization/src/commonMain/kotlin/net/mamoe/mirai/message/code/internal/impl.kt
@@ -53,6 +53,9 @@ internal inline fun String.forEachMiraiCode(crossinline block: (origin: String, 
             block(result.value, result.groups[3]!!.value, "")
         } else block(result.value, result.groups[1]!!.value, result.groups[2]?.value ?: "")
     }
+    if (lastIndex != this.length - 1) {
+        block(substring(lastIndex, this.length - 1), null, "")
+    }
 }
 
 internal object MiraiCodeParsers : Map<String, MiraiCodeParser> by mapOf(


### PR DESCRIPTION
修复成员进群后第一次发言触发改名事件，原因：成员进群时，对成员的nameCard属性赋值空字符串而非成员的昵称