### PR TITLE
Add low level api for getting group honor members list.

### DIFF
--- a/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/QQAndroidBot.common.kt
+++ b/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/QQAndroidBot.common.kt
@@ -607,6 +607,30 @@ internal abstract class QQAndroidBotBase constructor(
         return json.decodeFromString(GroupActiveData.serializer(), rep)
     }
 
+    @LowLevelAPI
+    @MiraiExperimentalAPI
+    override suspend fun _lowLevelGetGroupHonorListData(groupId: Long, type: GroupHonorType): GroupHonorListData? {
+        val data = network.async {
+            MiraiPlatformUtils.Http.get<String> {
+                url("https://qun.qq.com/interactive/honorlist")
+                parameter("gc", groupId)
+                parameter("type", type.value)
+                headers {
+                    append(
+                        "cookie",
+                        "uin=o${id};" +
+                                " skey=${client.wLoginSigInfo.sKey.data.encodeToString()};" +
+                                " p_uin=o${id};" +
+                                " p_skey=${client.wLoginSigInfo.psKeyMap["qun.qq.com"]?.data?.encodeToString()}; "
+                    )
+                }
+            }
+        }
+        val rep = data.await()
+        val jsonText = Regex("""window.__INITIAL_STATE__=(.+?)</script>""").find(rep)?.groupValues?.get(1)
+        return jsonText?.let { json.decodeFromString(GroupHonorListData.serializer(), it) }
+    }
+
     @JvmSynthetic
     @LowLevelAPI
     @MiraiExperimentalAPI

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -13,12 +13,12 @@ import net.mamoe.mirai.utils.MiraiExperimentalAPI
  */
 
 public enum class GroupHonorType(public val value: Int) {
-    // ACTIVE(7)        // 活跃头衔
     TALKATIVE(1),       // 龙王
     PERFORMER(2),       // 群聊之火
     LEGEND(3),          // 群聊炽焰
     STRONG_NEWBIE(5),   // 冒尖小春笋
     EMOTION(6),         // 快乐源泉
+    ACTIVE(7),          // 活跃头衔
     EXCLUSIVE(8),       // 特殊头衔
     MANAGE(9);          // 管理头衔
 
@@ -74,10 +74,10 @@ public data class GroupHonorListData(
     val exclusiveList: List<Tag?>? = null,
 
     @SerialName("activeObj")
-    val activeObj: PlaceHolder? = null,
+    val activeObj: Map<String, List<Tag?>?>? = null, // Key为活跃等级名, 如`冒泡`
 
     @SerialName("showActiveObj")
-    val showActiveObj: PlaceHolder? = null,
+    val showActiveObj: Map<String, Boolean?>? = null,
 
     @SerialName("myTitle")
     val myTitle: String?,
@@ -94,15 +94,6 @@ public data class GroupHonorListData(
     @SerialName("hwExcellentList")
     val hwExcellentList: List<Actor?>? = null
 ) {
-    /**
-     * 对于活跃头衔, 对象Key为等级名称, 可自定义, 故不固定, 此处未对其进行支持, 先占位
-     */
-    @Serializable
-    public data class PlaceHolder(
-        @SerialName("placeHolder")
-        val placeHolder: String? = null
-    )
-
     @Serializable
     public data class Language(
         @SerialName("code")

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -7,11 +7,13 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import net.mamoe.mirai.utils.MiraiExperimentalAPI
+import net.mamoe.mirai.utils.SinceMirai
 
 /**
  * 群荣誉信息
  */
-
+@MiraiExperimentalAPI
+@SinceMirai("1.3.0")
 public enum class GroupHonorType(public val value: Int) {
     TALKATIVE(1),       // 龙王
     PERFORMER(2),       // 群聊之火
@@ -21,13 +23,13 @@ public enum class GroupHonorType(public val value: Int) {
     ACTIVE(7),          // 活跃头衔
     EXCLUSIVE(8),       // 特殊头衔
     MANAGE(9);          // 管理头衔
-
     public companion object {
         public fun fromInt(value: Int): GroupHonorType = values().first { it.value == value }
     }
 }
 
 @MiraiExperimentalAPI
+@SinceMirai("1.3.0")
 @Serializable
 public data class GroupHonorListData(
     @SerialName("acceptLanguages")

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import net.mamoe.mirai.utils.MiraiExperimentalAPI
 import net.mamoe.mirai.utils.SinceMirai
+import kotlin.jvm.JvmStatic
 
 /**
  * 群荣誉信息
@@ -23,8 +24,9 @@ public enum class GroupHonorType(public val value: Int) {
     ACTIVE(7),          // 活跃头衔
     EXCLUSIVE(8),       // 特殊头衔
     MANAGE(9);          // 管理头衔
-    public companion object {
-        public fun fromInt(value: Int): GroupHonorType = values().first { it.value == value }
+    internal companion object {
+        @JvmStatic
+        internal fun deserializeFromInt(value: Int): GroupHonorType = values().first { it.value == value }
     }
 }
 
@@ -229,7 +231,7 @@ public data class GroupHonorListData(
         }
 
         override fun deserialize(decoder: Decoder): GroupHonorType {
-            return GroupHonorType.fromInt(decoder.decodeInt())
+            return GroupHonorType.deserializeFromInt(decoder.decodeInt())
         }
     }
 }

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -33,9 +33,6 @@ public data class GroupHonorListData(
     @SerialName("acceptLanguages")
     val acceptLanguages: List<Language?>? = null,
 
-    @SerialName("bkn")
-    val bkn: Int?,
-
     @SerialName("gc")
     val gc: String?,
 

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -95,7 +95,7 @@ public data class GroupHonorListData(
     val hasServerError: Boolean?,
 
     @SerialName("hwExcellentList")
-    val hwExcellentList: List<Actor?>? = null,
+    val hwExcellentList: List<Actor?>? = null
 ) {
     /**
      * 对于活跃头衔, 对象Key为等级名称, 可自定义, 故不固定, 此处未对其进行支持, 先占位
@@ -118,7 +118,7 @@ public data class GroupHonorListData(
         val region: String? = null,
 
         @SerialName("quality")
-        val quality: Double? = null,
+        val quality: Double? = null
     )
 
     @Serializable

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -187,22 +187,22 @@ public data class GroupHonorListData(
     @Serializable
     public data class LevelName(
         @SerialName("lvln1")
-        val lv1: String? = "潜水",
+        val lv1: String? = null,
 
         @SerialName("lvln2")
-        val lv2: String? = "冒泡",
+        val lv2: String? = null,
 
         @SerialName("lvln3")
-        val lv3: String? = "吐槽",
+        val lv3: String? = null,
 
         @SerialName("lvln4")
-        val lv4: String? = "活跃",
+        val lv4: String? = null,
 
         @SerialName("lvln5")
-        val lv5: String? = "话唠",
+        val lv5: String? = null,
 
         @SerialName("lvln6")
-        val lv6: String? = "传说"
+        val lv6: String? = null
     )
 
     @Serializable
@@ -235,7 +235,7 @@ public data class GroupHonorListData(
             PrimitiveSerialDescriptor("GroupHonorTypeSerializer", PrimitiveKind.INT)
 
         override fun serialize(encoder: Encoder, value: GroupHonorType) {
-            encoder.encodeString(value.toString())
+            encoder.encodeInt(value.value)
         }
 
         override fun deserialize(decoder: Decoder): GroupHonorType {

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/data/GroupHonorListData.kt
@@ -1,0 +1,245 @@
+package net.mamoe.mirai.data
+
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.mamoe.mirai.utils.MiraiExperimentalAPI
+
+/**
+ * 群荣誉信息
+ */
+
+public enum class GroupHonorType(public val value: Int) {
+    // ACTIVE(7)        // 活跃头衔
+    TALKATIVE(1),       // 龙王
+    PERFORMER(2),       // 群聊之火
+    LEGEND(3),          // 群聊炽焰
+    STRONG_NEWBIE(5),   // 冒尖小春笋
+    EMOTION(6),         // 快乐源泉
+    EXCLUSIVE(8),       // 特殊头衔
+    MANAGE(9);          // 管理头衔
+
+    public companion object {
+        public fun fromInt(value: Int): GroupHonorType = values().first { it.value == value }
+    }
+}
+
+@MiraiExperimentalAPI
+@Serializable
+public data class GroupHonorListData(
+    @SerialName("acceptLanguages")
+    val acceptLanguages: List<Language?>? = null,
+
+    @SerialName("bkn")
+    val bkn: Int?,
+
+    @SerialName("gc")
+    val gc: String?,
+
+    @Serializable(with = GroupHonorTypeSerializer::class)
+    @SerialName("type")
+    val type: GroupHonorType?,
+
+    @SerialName("uin")
+    val uin: String?,
+
+    @SerialName("talkativeList")
+    val talkativeList: List<Talkative?>? = null,
+
+    @SerialName("currentTalkative")
+    val currentTalkative: CurrentTalkative? = null,
+
+    @SerialName("actorList")
+    val actorList: List<Actor?>? = null,
+
+    @SerialName("legendList")
+    val legendList: List<Actor?>? = null,
+
+    @SerialName("newbieList")
+    val newbieList: List<Actor?>? = null,
+
+    @SerialName("strongnewbieList")
+    val strongNewbieList: List<Actor?>? = null,
+
+    @SerialName("emotionList")
+    val emotionList: List<Actor?>? = null,
+
+    @SerialName("levelname")
+    val levelName: LevelName? = null,
+
+    @SerialName("manageList")
+    val manageList: List<Tag?>? = null,
+
+    @SerialName("exclusiveList")
+    val exclusiveList: List<Tag?>? = null,
+
+    @SerialName("activeObj")
+    val activeObj: PlaceHolder? = null,
+
+    @SerialName("showActiveObj")
+    val showActiveObj: PlaceHolder? = null,
+
+    @SerialName("myTitle")
+    val myTitle: String?,
+
+    @SerialName("myIndex")
+    val myIndex: Int? = 0,
+
+    @SerialName("myAvatar")
+    val myAvatar: String?,
+
+    @SerialName("hasServerError")
+    val hasServerError: Boolean?,
+
+    @SerialName("hwExcellentList")
+    val hwExcellentList: List<Actor?>? = null,
+) {
+    /**
+     * 对于活跃头衔, 对象Key为等级名称, 可自定义, 故不固定, 此处未对其进行支持, 先占位
+     */
+    @Serializable
+    public data class PlaceHolder(
+        @SerialName("placeHolder")
+        val placeHolder: String? = null
+    )
+
+    @Serializable
+    public data class Language(
+        @SerialName("code")
+        val code: String? = null,
+
+        @SerialName("script")
+        val script: String? = null,
+
+        @SerialName("region")
+        val region: String? = null,
+
+        @SerialName("quality")
+        val quality: Double? = null,
+    )
+
+    @Serializable
+    public data class Actor(
+        @SerialName("uin")
+        val uin: Long? = 0,
+
+        @SerialName("avatar")
+        val avatar: String? = null,
+
+        @SerialName("name")
+        val name: String? = null,
+
+        @SerialName("desc")
+        val desc: String? = null,
+
+        @SerialName("btnText")
+        val btnText: String? = null,
+
+        @SerialName("text")
+        val text: String? = null,
+
+        @SerialName("icon")
+        val icon: Int?
+    )
+
+    @Serializable
+    public data class Talkative(
+        @SerialName("uin")
+        val uin: Long? = 0,
+
+        @SerialName("avatar")
+        val avatar: String? = null,
+
+        @SerialName("name")
+        val name: String? = null,
+
+        @SerialName("desc")
+        val desc: String? = null,
+
+        @SerialName("btnText")
+        val btnText: String? = null,
+
+        @SerialName("text")
+        val text: String? = null
+    )
+
+    @Serializable
+    public data class CurrentTalkative(
+        @SerialName("uin")
+        val uin: Long? = 0,
+
+        @SerialName("day_count")
+        val dayCount: Int? = null,
+
+        @SerialName("avatar")
+        val avatar: String? = null,
+
+        @SerialName("avatar_size")
+        val avatarSize: Int? = null,
+
+        @SerialName("nick")
+        val nick: String? = null
+    )
+
+    @Serializable
+    public data class LevelName(
+        @SerialName("lvln1")
+        val lv1: String? = "潜水",
+
+        @SerialName("lvln2")
+        val lv2: String? = "冒泡",
+
+        @SerialName("lvln3")
+        val lv3: String? = "吐槽",
+
+        @SerialName("lvln4")
+        val lv4: String? = "活跃",
+
+        @SerialName("lvln5")
+        val lv5: String? = "话唠",
+
+        @SerialName("lvln6")
+        val lv6: String? = "传说"
+    )
+
+    @Serializable
+    public data class Tag(
+        @SerialName("uin")
+        val uin: Long? = 0,
+
+        @SerialName("avatar")
+        val avatar: String? = null,
+
+        @SerialName("name")
+        val name: String? = null,
+
+        @SerialName("btnText")
+        val btnText: String? = null,
+
+        @SerialName("text")
+        val text: String? = null,
+
+        @SerialName("tag")
+        val tag: String? = null,  // 头衔
+
+        @SerialName("tagColor")
+        val tagColor: String? = null
+    )
+
+    @Serializer(forClass = GroupHonorType::class)
+    public object GroupHonorTypeSerializer : KSerializer<GroupHonorType> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("GroupHonorTypeSerializer", PrimitiveKind.INT)
+
+        override fun serialize(encoder: Encoder, value: GroupHonorType) {
+            encoder.encodeString(value.toString())
+        }
+
+        override fun deserialize(decoder: Decoder): GroupHonorType {
+            return GroupHonorType.fromInt(decoder.decodeInt())
+        }
+    }
+}

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/lowLevelApi.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/lowLevelApi.kt
@@ -123,6 +123,14 @@ public interface LowLevelBotAPIAccessor {
 
 
     /**
+     * 获取群荣誉信息
+     */
+    @LowLevelAPI
+    @MiraiExperimentalAPI
+    public suspend fun _lowLevelGetGroupHonorListData(groupId: Long, type: GroupHonorType): GroupHonorListData?
+
+
+    /**
      * 处理一个账号请求添加机器人为好友的事件
      */
     @LowLevelAPI


### PR DESCRIPTION
添加用于获取群荣誉数据的low level API, `enum`中字段参考官方字段值

已可获取:

| 数据 | 对应`enum` |
| ------------ | ---------------------- |
| 龙王            | TALKATIVE　            |
| 群聊之火     | PERFORMER        　|
| 群聊炽焰     | LEGEND　               |
| 冒尖小春笋 | STRONG_NEWBIE　|
| 快乐源泉     | EMOTION　            |
| 活跃头衔     | ACTIVE                 　|
| 特殊头衔     | EXCLUSIVE           　|
| 管理头衔     | MANAGE             　|