### PR TITLE
Add send silk format voice support, fix typo.

### DIFF
--- a/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/contact/GroupImpl.kt
+++ b/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/contact/GroupImpl.kt
@@ -449,7 +449,7 @@ internal class GroupImpl(
      * 上传一个语音消息以备发送.
      * 请注意，这是一个实验性api且随时会被删除
      * @throws EventCancelledException 当发送消息事件被取消
-     * @throws OverFileSizeMaxException 当图片文件过大而被服务器拒绝上传时. (最大大小约为 1 MB)
+     * @throws OverFileSizeMaxException 当语音文件过大而被服务器拒绝上传时. (最大大小约为 1 MB)
      */
     @JvmSynthetic
     @MiraiExperimentalAPI
@@ -460,9 +460,16 @@ internal class GroupImpl(
             throw  OverFileSizeMaxException()
         }
         val md5 = MiraiPlatformUtils.md5(content)
+        val codec = with(content.copyOfRange(0, 10).toUHexString("")) {
+            when {
+                startsWith("2321414D52") -> 0             // amr
+                startsWith("02232153494C4B5F5633") -> 1  // silk V3
+                else -> 0                               // use amr by default
+            }
+        }
         return bot.network.run {
             val response: PttStore.GroupPttUp.Response.RequireUpload =
-                PttStore.GroupPttUp(bot.client, bot.id, 0L, md5, content.size.toLong()).sendAndExpect()
+                PttStore.GroupPttUp(bot.client, bot.id, 0L, md5, content.size.toLong(), codec).sendAndExpect()
             HighwayHelper.uploadPttToServers(
                 bot,
                 response.uploadIpList.zip(response.uploadPortList),

--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/contact/Group.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/contact/Group.kt
@@ -175,7 +175,7 @@ public abstract class Group : Contact(), CoroutineScope {
     /**
      * 上传一个语音消息以备发送.
      * 请手动关闭输入流
-     * 请使用mar格式
+     * 请使用amr或silk格式
      * 请注意，这是一个实验性api且随时会被删除
      * @throws EventCancelledException 当发送消息事件被取消
      * @throws OverFileSizeMaxException 当图片文件过大而被服务器拒绝上传时. (最大大小约为 1 MB)

--- a/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/message/SendImageUtilsJvm.kt
+++ b/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/message/SendImageUtilsJvm.kt
@@ -119,9 +119,9 @@ public suspend fun File.uploadAsImage(contact: Contact): Image {
 }
 
 /**
- * 在 [Dispatchers.IO] 中将文件作为语音上传后构造 [Image]
+ * 在 [Dispatchers.IO] 中将文件作为语音上传后构造 [Voice]
  * 请手动关闭输入流
- * 请使用mar格式
+ * 请使用amr或silk格式
  * 注意，这只是个实验性功能且随时可能会删除
  * @throws OverFileSizeMaxException
  */


### PR DESCRIPTION
- 添加发送silk格式的语音文件支持(`codec`为`1`), 判断语音格式代码格式来自`ExternalImage`中的`detectFormatName`
- 修复几处语音发送API相关的typo