### PR TITLE
Make BotJoinGroupEvent.Active and .Invite inherit BotJoinGroupEvent

### DIFF
--- a/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/event/events/group.kt
+++ b/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/event/events/group.kt
@@ -99,7 +99,7 @@ public data class BotUnmuteEvent internal constructor(
 /**
  * Bot 成功加入了一个新群
  */
-public sealed class BotJoinGroupEvent : GroupEvent, Packet, AbstractEvent() {
+public sealed class BotJoinGroupEvent : GroupEvent, BotPassiveEvent, Packet, AbstractEvent() {
     public abstract override val group: Group
 
     /**
@@ -108,7 +108,7 @@ public sealed class BotJoinGroupEvent : GroupEvent, Packet, AbstractEvent() {
     @MiraiExperimentalAPI
     public data class Active internal constructor(
         public override val group: Group
-    ) : BotPassiveEvent, GroupEvent, Packet, AbstractEvent() {
+    ) : BotJoinGroupEvent() {
         public override fun toString(): String = "BotJoinGroupEvent.Active(group=$group)"
     }
 
@@ -123,7 +123,7 @@ public sealed class BotJoinGroupEvent : GroupEvent, Packet, AbstractEvent() {
          * 邀请人
          */
         public val invitor: Member
-    ) : BotPassiveEvent, GroupEvent, Packet, AbstractEvent() {
+    ) : BotJoinGroupEvent() {
         public override val group: Group get() = invitor.group
 
         public override fun toString(): String {


### PR DESCRIPTION
让`BotJoinGroupEvent.Active`, `BotJoinGroupEvent.Invite`事件继承`BotJoinGroupEvent`

目前, 下方测试代码中第一个`when`block不会被触发, 而类似事件如`MemberJoinEvent`中`Invite`和`Active`都继承了其父类, 所以类似block可以正确触发
```kt
        bot.subscribeAlways<BotEvent> {
            when (this) {
                is BotJoinGroupEvent -> {
                    println("Bot Join Event !!!!!!!!!!!!!!!")
                    when (it) {
                        is BotJoinGroupEvent.Active -> println("1: Bot joined group: ${group.name}")
                        is BotJoinGroupEvent.Invite -> println("1: Bot joined group by invitation! Group: ${group.name}")
                    }
                }
                is BotJoinGroupEvent.Active -> println("2: Bot joined group: ${group.name}")
                is BotJoinGroupEvent.Invite -> println("2: Bot joined group by invitation! Group: ${group.name}")
            }
        }
```