### PR TITLE
去掉耻辱柱1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 这里收集了部分已知违反mirai协议的人或组织, 并为其他人排除可能的隐患
 
 
-1: QQ群(780718**3), 创建者(QQ=1783166687) 群管理(github=https://github.com/Pai2Chen), 伪造“官方群”上传“加密插件” 企图不明
 
-2: 
+1: 
 <img src="https://github.com/mamoe/mirai/raw/rm/Screenshot_20200821-002427.jpg" width="200" height="150" />


### PR DESCRIPTION
您好，我是780718903群的群主

关于在Github上的声明，我想在这里说明一下：
1.本群确实只是提供一个学习交流平台，希望更多的开发者能够参与Mirai生态的建设
2.群里遵守Mirai声明以及各项协议，也约束好了群员
3.群里的加密压缩包本意是为了杜绝伸手党以及被滥用的行为
4.加密的压缩包均为原酷Q的插件，包括DLL以及JSON文件
5.对于协议的变化我们会尽快按要求完成相应的整改

对于这一切误会，我和我的群友都十分的抱歉，
希望你们能够删除Github上对于我们群的一些误会，十分感谢
https://github.com/mamoe/mirai/tree/rm