### PR TITLE
Fix: QQAndroidBotNetworkHandler.handlePacket

### DIFF
--- a/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/network/QQAndroidBotNetworkHandler.kt
+++ b/mirai-core-qqandroid/src/commonMain/kotlin/net/mamoe/mirai/qqandroid/network/QQAndroidBotNetworkHandler.kt
@@ -518,13 +518,13 @@ internal class QQAndroidBotNetworkHandler(coroutineContext: CoroutineContext, bo
             }
         }
 
-        packetListeners.forEach { listener ->
-            if (listener.filter(commandName, sequenceId) && packetListeners.remove(listener)) {
-                listener.complete(packet)
-            }
-        }
-
         packetFactory?.run {
+            packetListeners.forEach { listener ->
+                if (listener.filter(commandName, sequenceId) && packetListeners.remove(listener)) {
+                    listener.complete(packet)
+                }
+            }
+
             when (this) {
                 is OutgoingPacketFactory<P> -> bot.handle(packet)
                 is IncomingPacketFactory<P> -> bot.handle(packet, sequenceId)?.sendWithoutExpect()


### PR DESCRIPTION
sendAndExpect should not expect element of MultiPacket
Also, this will always cause a cast error when expect a MultiPacket, since element are handled and received before it.