### PR TITLE
Use emptyList() as the default value of List<*> for ProtoBuf

### DIFF
--- a/mirai-core/src/commonMain/kotlin/message/conversions.kt
+++ b/mirai-core/src/commonMain/kotlin/message/conversions.kt
@@ -262,8 +262,9 @@ internal fun MsgComm.Msg.toMessageChain(
 // These two functions have difference method signature, don't combine.
 
 internal fun ImMsgBody.SourceMsg.toMessageChain(bot: Bot, groupIdOrZero: Long): MessageChain {
-    val elements = this.elems!!
-
+    val elements = this.elems
+    if (elements.isEmpty())
+        error("elements for SourceMsg is empty")
     return buildMessageChain(elements.size + 1) {
         +OfflineMessageSourceImplBySourceMsg(delegate = this@toMessageChain, bot = bot, groupIdOrZero = groupIdOrZero)
         elements.joinToMessageChain(groupIdOrZero, bot, this)

--- a/mirai-core/src/commonMain/kotlin/message/offlineSourceImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/message/offlineSourceImpl.kt
@@ -74,7 +74,7 @@ internal class OfflineMessageSourceImplBySourceMsg(
 
     override var isRecalledOrPlanned: MiraiAtomicBoolean = MiraiAtomicBoolean(false)
     override val sequenceId: Int
-        get() = delegate.origSeqs?.first() ?: error("cannot find sequenceId")
+        get() = delegate.origSeqs.firstOrNull() ?: error("cannot find sequenceId")
     override val internalId: Int
         get() = delegate.pbReserve.loadAs(SourceMsg.ResvAttr.serializer()).origUids?.toInt() ?: 0
     override val time: Int get() = delegate.time

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x352.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x352.kt
@@ -52,19 +52,19 @@ internal class Cmd0x352 : ProtoBuf {
         @ProtoNumber(2) @JvmField val clientIp: Int = 0,
         @ProtoNumber(3) @JvmField val result: Int = 0,
         @ProtoNumber(4) @JvmField val failMsg: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(5) @JvmField val bytesThumbDownUrl: List<ByteArray>? = null,
-        @ProtoNumber(6) @JvmField val bytesOriginalDownUrl: List<ByteArray>? = null,
+        @ProtoNumber(5) @JvmField val bytesThumbDownUrl: List<ByteArray> = emptyList(),
+        @ProtoNumber(6) @JvmField val bytesOriginalDownUrl: List<ByteArray> = emptyList(),
         @ProtoNumber(7) @JvmField val msgImgInfo: ImgInfo? = null,
-        @ProtoNumber(8) @JvmField val uint32DownIp: List<Int>? = null,
-        @ProtoNumber(9) @JvmField val uint32DownPort: List<Int>? = null,
+        @ProtoNumber(8) @JvmField val uint32DownIp: List<Int> = emptyList(),
+        @ProtoNumber(9) @JvmField val uint32DownPort: List<Int> = emptyList(),
         @ProtoNumber(10) @JvmField val thumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(11) @JvmField val originalDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(12) @JvmField val downDomain: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(13) @JvmField val bytesBigDownUrl: List<ByteArray>? = null,
+        @ProtoNumber(13) @JvmField val bytesBigDownUrl: List<ByteArray> = emptyList(),
         @ProtoNumber(14) @JvmField val bigDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(15) @JvmField val bigThumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(16) @JvmField val httpsUrlFlag: Int = 0,
-        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -89,19 +89,19 @@ internal class Cmd0x352 : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val subcmd: Int = 0, //2是GetImgUrlReq 1是UploadImgReq
-        @ProtoNumber(2) @JvmField val msgTryupImgReq: List<TryUpImgReq>? = null,// optional
-        @ProtoNumber(3) @JvmField val msgGetimgUrlReq: List<GetImgUrlReq>? = null,// optional
-        @ProtoNumber(4) @JvmField val msgDelImgReq: List<DelImgReq>? = null,
+        @ProtoNumber(2) @JvmField val msgTryupImgReq: List<TryUpImgReq> = emptyList(),// optional
+        @ProtoNumber(3) @JvmField val msgGetimgUrlReq: List<GetImgUrlReq> = emptyList(),// optional
+        @ProtoNumber(4) @JvmField val msgDelImgReq: List<DelImgReq> = emptyList(),
         @ProtoNumber(10) @JvmField val netType: Int = 3// 数据网络=5
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val subcmd: Int = 0,
-        @ProtoNumber(2) @JvmField val msgTryupImgRsp: List<TryUpImgRsp>? = null,
-        @ProtoNumber(3) @JvmField val msgGetimgUrlRsp: List<GetImgUrlRsp>? = null,
+        @ProtoNumber(2) @JvmField val msgTryupImgRsp: List<TryUpImgRsp> = emptyList(),
+        @ProtoNumber(3) @JvmField val msgGetimgUrlRsp: List<GetImgUrlRsp> = emptyList(),
         @ProtoNumber(4) @JvmField val boolNewBigchan: Boolean = false,
-        @ProtoNumber(5) @JvmField val msgDelImgRsp: List<DelImgRsp>? = null,
+        @ProtoNumber(5) @JvmField val msgDelImgRsp: List<DelImgRsp> = emptyList(),
         @ProtoNumber(10) @JvmField val failMsg: String? = ""
     ) : ProtoBuf
 
@@ -150,8 +150,8 @@ internal class Cmd0x352 : ProtoBuf {
         @ProtoNumber(4) @JvmField val failMsg: String? = "",
         @ProtoNumber(5) @JvmField val boolFileExit: Boolean = false,
         @ProtoNumber(6) @JvmField val msgImgInfo: ImgInfo? = null,
-        @ProtoNumber(7) @JvmField val uint32UpIp: List<Int>? = null,
-        @ProtoNumber(8) @JvmField val uint32UpPort: List<Int>? = null,
+        @ProtoNumber(7) @JvmField val uint32UpIp: List<Int> = emptyList(),
+        @ProtoNumber(8) @JvmField val uint32UpPort: List<Int> = emptyList(),
         @ProtoNumber(9) @JvmField val upUkey: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(10) @JvmField val upResid: String = "",
         @ProtoNumber(11) @JvmField val upUuid: String = "",
@@ -159,7 +159,7 @@ internal class Cmd0x352 : ProtoBuf {
         @ProtoNumber(13) @JvmField val blockSize: Long = 0L,
         @ProtoNumber(14) @JvmField val encryptDstip: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(15) @JvmField val roamdays: Int = 0,
-        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(60) @JvmField val thumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(61) @JvmField val originalDownPara: ByteArray = EMPTY_BYTE_ARRAY,

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x388.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x388.kt
@@ -42,12 +42,12 @@ internal class ExpRoamPicInfo(
 
     @Serializable
 internal class ExtensionCommPicTryUp(
-        @ProtoNumber(1) @JvmField val bytesExtinfo: List<ByteArray>? = null
+        @ProtoNumber(1) @JvmField val bytesExtinfo: List<ByteArray> = emptyList()
     ) : ProtoBuf
 
     @Serializable
 internal class ExtensionExpRoamTryUp(
-        @ProtoNumber(1) @JvmField val msgExproamPicInfo: List<ExpRoamPicInfo>? = null
+        @ProtoNumber(1) @JvmField val msgExproamPicInfo: List<ExpRoamPicInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -81,21 +81,21 @@ internal class GetImgUrlRsp(
         @ProtoNumber(3) @JvmField val result: Int = 0,
         @ProtoNumber(4) @JvmField val failMsg: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(5) @JvmField val msgImgInfo: ImgInfo? = null,
-        @ProtoNumber(6) @JvmField val bytesThumbDownUrl: List<ByteArray>? = null,
-        @ProtoNumber(7) @JvmField val bytesOriginalDownUrl: List<ByteArray>? = null,
-        @ProtoNumber(8) @JvmField val bytesBigDownUrl: List<ByteArray>? = null,
-        @ProtoNumber(9) @JvmField val uint32DownIp: List<Int>? = null,
-        @ProtoNumber(10) @JvmField val uint32DownPort: List<Int>? = null,
+        @ProtoNumber(6) @JvmField val bytesThumbDownUrl: List<ByteArray> = emptyList(),
+        @ProtoNumber(7) @JvmField val bytesOriginalDownUrl: List<ByteArray> = emptyList(),
+        @ProtoNumber(8) @JvmField val bytesBigDownUrl: List<ByteArray> = emptyList(),
+        @ProtoNumber(9) @JvmField val uint32DownIp: List<Int> = emptyList(),
+        @ProtoNumber(10) @JvmField val uint32DownPort: List<Int> = emptyList(),
         @ProtoNumber(11) @JvmField val downDomain: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(12) @JvmField val thumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(13) @JvmField val originalDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(14) @JvmField val bigDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(15) @JvmField val fileId: Long = 0L,
         @ProtoNumber(16) @JvmField val autoDownType: Int = 0,
-        @ProtoNumber(17) @JvmField val uint32OrderDownType: List<Int>? = null,
+        @ProtoNumber(17) @JvmField val uint32OrderDownType: List<Int> = emptyList(),
         @ProtoNumber(19) @JvmField val bigThumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(20) @JvmField val httpsUrlFlag: Int = 0,
-        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -124,15 +124,15 @@ internal class GetPttUrlRsp(
         @ProtoNumber(2) @JvmField val fileMd5: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(3) @JvmField val result: Int = 0,
         @ProtoNumber(4) @JvmField val failMsg: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(5) @JvmField val bytesDownUrl: List<ByteArray>? = null,
-        @ProtoNumber(6) @JvmField val uint32DownIp: List<Int>? = null,
-        @ProtoNumber(7) @JvmField val uint32DownPort: List<Int>? = null,
+        @ProtoNumber(5) @JvmField val bytesDownUrl: List<ByteArray> = emptyList(),
+        @ProtoNumber(6) @JvmField val uint32DownIp: List<Int> = emptyList(),
+        @ProtoNumber(7) @JvmField val uint32DownPort: List<Int> = emptyList(),
         @ProtoNumber(8) @JvmField val downDomain: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(9) @JvmField val downPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(10) @JvmField val fileId: Long = 0L,
         @ProtoNumber(11) @JvmField val transferType: Int = 0,
         @ProtoNumber(12) @JvmField val allowRetry: Int = 0,
-        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgDownIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(28) @JvmField val strDomain: String = ""
     ) : ProtoBuf
@@ -168,12 +168,12 @@ internal class PicSize(
 internal class ReqBody(
         @ProtoNumber(1) @JvmField val netType: Int = 0,
         @ProtoNumber(2) @JvmField val subcmd: Int = 0,
-        @ProtoNumber(3) @JvmField val msgTryupImgReq: List<TryUpImgReq>? = null,
-        @ProtoNumber(4) @JvmField val msgGetimgUrlReq: List<GetImgUrlReq>? = null,
-        @ProtoNumber(5) @JvmField val msgTryupPttReq: List<TryUpPttReq>? = null,
-        @ProtoNumber(6) @JvmField val msgGetpttUrlReq: List<GetPttUrlReq>? = null,
+        @ProtoNumber(3) @JvmField val msgTryupImgReq: List<TryUpImgReq> = emptyList(),
+        @ProtoNumber(4) @JvmField val msgGetimgUrlReq: List<GetImgUrlReq> = emptyList(),
+        @ProtoNumber(5) @JvmField val msgTryupPttReq: List<TryUpPttReq> = emptyList(),
+        @ProtoNumber(6) @JvmField val msgGetpttUrlReq: List<GetPttUrlReq> = emptyList(),
         @ProtoNumber(7) @JvmField val commandId: Int = 0,
-        @ProtoNumber(8) @JvmField val msgDelImgReq: List<DelImgReq>? = null,
+        @ProtoNumber(8) @JvmField val msgDelImgReq: List<DelImgReq> = emptyList(),
         @ProtoNumber(1001) @JvmField val extension: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -181,11 +181,11 @@ internal class ReqBody(
 internal class RspBody(
         @ProtoNumber(1) @JvmField val clientIp: Int = 0,
         @ProtoNumber(2) @JvmField val subcmd: Int = 0,
-        @ProtoNumber(3) @JvmField val msgTryupImgRsp: List<TryUpImgRsp>? = null,
-        @ProtoNumber(4) @JvmField val msgGetimgUrlRsp: List<GetImgUrlRsp>? = null,
-        @ProtoNumber(5) @JvmField val msgTryupPttRsp: List<TryUpPttRsp>? = null,
-        @ProtoNumber(6) @JvmField val msgGetpttUrlRsp: List<GetPttUrlRsp>? = null,
-        @ProtoNumber(7) @JvmField val msgDelImgRsp: List<DelImgRsp>? = null
+        @ProtoNumber(3) @JvmField val msgTryupImgRsp: List<TryUpImgRsp> = emptyList(),
+        @ProtoNumber(4) @JvmField val msgGetimgUrlRsp: List<GetImgUrlRsp> = emptyList(),
+        @ProtoNumber(5) @JvmField val msgTryupPttRsp: List<TryUpPttRsp> = emptyList(),
+        @ProtoNumber(6) @JvmField val msgGetpttUrlRsp: List<GetPttUrlRsp> = emptyList(),
+        @ProtoNumber(7) @JvmField val msgDelImgRsp: List<DelImgRsp> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -219,14 +219,14 @@ internal class TryUpImgRsp(
         @ProtoNumber(3) @JvmField val failMsg: String = "",
         @ProtoNumber(4) @JvmField val boolFileExit: Boolean = false,
         @ProtoNumber(5) @JvmField val msgImgInfo: ImgInfo? = null,
-        @ProtoNumber(6) @JvmField val uint32UpIp: List<Int>? = null,
-        @ProtoNumber(7) @JvmField val uint32UpPort: List<Int>? = null,
+        @ProtoNumber(6) @JvmField val uint32UpIp: List<Int> = emptyList(),
+        @ProtoNumber(7) @JvmField val uint32UpPort: List<Int> = emptyList(),
         @ProtoNumber(8) @JvmField val upUkey: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(9) @JvmField val fileid: Long = 0L,
         @ProtoNumber(10) @JvmField val upOffset: Long = 0L,
         @ProtoNumber(11) @JvmField val blockSize: Long = 0L,
         @ProtoNumber(12) @JvmField val boolNewBigChan: Boolean = false,
-        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(1001) @JvmField val msgInfo4busi: TryUpInfo4Busi? = null
     ) : ProtoBuf
@@ -266,15 +266,15 @@ internal class TryUpPttRsp(
         @ProtoNumber(2) @JvmField val result: Int = 0,
         @ProtoNumber(3) @JvmField val failMsg: ByteArray? = null,
         @ProtoNumber(4) @JvmField val boolFileExit: Boolean = false,
-        @ProtoNumber(5) @JvmField val uint32UpIp: List<Int>? = null,
-        @ProtoNumber(6) @JvmField val uint32UpPort: List<Int>? = null,
+        @ProtoNumber(5) @JvmField val uint32UpIp: List<Int> = emptyList(),
+        @ProtoNumber(6) @JvmField val uint32UpPort: List<Int> = emptyList(),
         @ProtoNumber(7) @JvmField val upUkey: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(8) @JvmField val fileid: Long = 0L,
         @ProtoNumber(9) @JvmField val upOffset: Long = 0L,
         @ProtoNumber(10) @JvmField val blockSize: Long = 0L,
         @ProtoNumber(11) @JvmField val fileKey: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(12) @JvmField val channelType: Int = 0,
-        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info>? = null,
+        @ProtoNumber(26) @JvmField val msgUpIp6: List<IPv6Info> = emptyList(),
         @ProtoNumber(27) @JvmField val clientIp6: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x857.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x857.kt
@@ -98,7 +98,7 @@ internal class TroopTips0x857 : ProtoBuf {
         @ProtoNumber(4) @JvmField val c2cType: Int = 0,
         @ProtoNumber(5) @JvmField val serviceType: Int = 0,
         @ProtoNumber(6) @JvmField val templId: Long = 0L,
-        @ProtoNumber(7) @JvmField val msgTemplParam: List<TemplParam>? = null,
+        @ProtoNumber(7) @JvmField val msgTemplParam: List<TemplParam> = emptyList(),
         @ProtoNumber(8) @JvmField val content: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(10) @JvmField val tipsSeqId: Long = 0L,
         @ProtoNumber(100) @JvmField val pbReserv: ByteArray = EMPTY_BYTE_ARRAY
@@ -113,7 +113,7 @@ internal class TroopTips0x857 : ProtoBuf {
         @ProtoNumber(5) @JvmField val total: Int = 0,
         @ProtoNumber(6) @JvmField val interval: Int = 0,
         @ProtoNumber(7) @JvmField val finish: Int = 0,
-        @ProtoNumber(8) @JvmField val uin: List<Long>? = null,
+        @ProtoNumber(8) @JvmField val uin: List<Long> = emptyList(),
         @ProtoNumber(9) @JvmField val action: Int = 0
     ) : ProtoBuf
 
@@ -130,8 +130,8 @@ internal class TroopTips0x857 : ProtoBuf {
 
     @Serializable
     internal class InstCtrl(
-        @ProtoNumber(1) @JvmField val msgSendToInst: List<InstInfo>? = null,
-        @ProtoNumber(2) @JvmField val msgExcludeInst: List<InstInfo>? = null,
+        @ProtoNumber(1) @JvmField val msgSendToInst: List<InstInfo> = emptyList(),
+        @ProtoNumber(2) @JvmField val msgExcludeInst: List<InstInfo> = emptyList(),
         @ProtoNumber(3) @JvmField val msgFromInst: InstInfo? = null
     ) : ProtoBuf
 
@@ -201,7 +201,7 @@ internal class TroopTips0x857 : ProtoBuf {
     internal class MessageRecallReminder(
         @ProtoNumber(1) @JvmField val uin: Long = 0L,
         @ProtoNumber(2) @JvmField val nickname: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(3) @JvmField val recalledMsgList: List<MessageMeta> = listOf(),
+        @ProtoNumber(3) @JvmField val recalledMsgList: List<MessageMeta> = emptyList(),
         @ProtoNumber(4) @JvmField val reminderContent: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(5) @JvmField val userdef: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(6) @JvmField val groupType: Int = 0,
@@ -288,7 +288,7 @@ internal class TroopTips0x857 : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val optUint64GroupCode: Long = 0L,
-        @ProtoNumber(2) @JvmField val uint64Memberuins: List<Long>? = null,
+        @ProtoNumber(2) @JvmField val uint64Memberuins: List<Long> = emptyList(),
         @ProtoNumber(3) @JvmField val optUint32Offline: Int = 0,
         @ProtoNumber(4) @JvmField val msgInstCtrl: InstCtrl? = null,
         @ProtoNumber(5) @JvmField val optBytesMsg: ByteArray = EMPTY_BYTE_ARRAY,
@@ -351,19 +351,19 @@ internal class TroopTips0x857 : ProtoBuf {
         @ProtoNumber(2) @JvmField val gameRoom: Long = 0L,
         @ProtoNumber(3) @JvmField val enumGameState: Int = 0,
         @ProtoNumber(4) @JvmField val gameRound: Int = 0,
-        @ProtoNumber(5) @JvmField val roles: List<Role>? = null,
+        @ProtoNumber(5) @JvmField val roles: List<Role> = emptyList(),
         @ProtoNumber(6) @JvmField val speaker: Long = 0L,
         @ProtoNumber(7) @JvmField val judgeUin: Long = 0L,
         @ProtoNumber(8) @JvmField val judgeWords: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(9) @JvmField val enumOperation: Int = 0,
         @ProtoNumber(10) @JvmField val srcUser: Long = 0L,
         @ProtoNumber(11) @JvmField val dstUser: Long = 0L,
-        @ProtoNumber(12) @JvmField val deadUsers: List<Long>? = null,
+        @ProtoNumber(12) @JvmField val deadUsers: List<Long> = emptyList(),
         @ProtoNumber(13) @JvmField val gameResult: Int = 0,
         @ProtoNumber(14) @JvmField val timeoutSec: Int = 0,
         @ProtoNumber(15) @JvmField val killConfirmed: Int = 0,
         @ProtoNumber(16) @JvmField val judgeNickname: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(17) @JvmField val votedTieUsers: List<Long>? = null
+        @ProtoNumber(17) @JvmField val votedTieUsers: List<Long> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class GameRecord(

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x858.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Cmd0x858.kt
@@ -21,7 +21,7 @@ internal class GoldMsgTipsElem(
         @ProtoNumber(5) @JvmField val total: Int = 0,
         @ProtoNumber(6) @JvmField val interval: Int = 0,
         @ProtoNumber(7) @JvmField val finish: Int = 0,
-        @ProtoNumber(8) @JvmField val uin: List<Long>? = null,
+        @ProtoNumber(8) @JvmField val uin: List<Long> = emptyList(),
         @ProtoNumber(9) @JvmField val action: Int = 0
     ) : ProtoBuf
 
@@ -29,7 +29,7 @@ internal class GoldMsgTipsElem(
 internal class MessageRecallReminder(
         @ProtoNumber(1) @JvmField val uin: Long = 0L,
         @ProtoNumber(2) @JvmField val nickname: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(3) @JvmField val recalledMsgList: List<MessageMeta> = listOf(),
+        @ProtoNumber(3) @JvmField val recalledMsgList: List<MessageMeta> = emptyList(),
         @ProtoNumber(4) @JvmField val reminderContent: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(5) @JvmField val userdef: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf {

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Define.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Define.kt
@@ -26,7 +26,7 @@ internal class Common : ProtoBuf {
         @ProtoNumber(8) @JvmField val msgBindFri: BindInfo? = null,
         @ProtoNumber(11) @JvmField val desc: String = "",
         @ProtoNumber(31) @JvmField val level: Int = 0,
-        @ProtoNumber(36) @JvmField val taskinfos: List<MedalTaskInfo>? = null,
+        @ProtoNumber(36) @JvmField val taskinfos: List<MedalTaskInfo> = emptyList(),
         @ProtoNumber(40) @JvmField val point: Int = 0,
         @ProtoNumber(41) @JvmField val pointLevel2: Int = 0,
         @ProtoNumber(42) @JvmField val pointLevel3: Int = 0,
@@ -67,7 +67,7 @@ internal class AppointDefine : ProtoBuf {
     @Serializable
     internal class ADFeedContent(
         @ProtoNumber(1) @JvmField val msgUserInfo: UserInfo? = null,
-        @ProtoNumber(2) @JvmField val strPicUrl: List<String> = listOf(),
+        @ProtoNumber(2) @JvmField val strPicUrl: List<String> = emptyList(),
         @ProtoNumber(3) @JvmField val msgText: RichText? = null,
         @ProtoNumber(4) @JvmField val attendInfo: String = "",
         @ProtoNumber(5) @JvmField val actionUrl: String = "",
@@ -79,7 +79,7 @@ internal class AppointDefine : ProtoBuf {
 
     @Serializable
     internal class RichText(
-        @ProtoNumber(1) @JvmField val msgElems: List<Elem>? = null
+        @ProtoNumber(1) @JvmField val msgElems: List<Elem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -164,7 +164,7 @@ internal class AppointDefine : ProtoBuf {
     @Serializable
     internal class InterestTag(
         @ProtoNumber(1) @JvmField val tagType: Int = 0,
-        @ProtoNumber(2) @JvmField val msgTagList: List<InterestItem>? = null
+        @ProtoNumber(2) @JvmField val msgTagList: List<InterestItem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -210,9 +210,9 @@ internal class AppointDefine : ProtoBuf {
         @ProtoNumber(5) @JvmField val publishTime: Long = 0,
         @ProtoNumber(6) @JvmField val praiseCount: Int = 0,
         @ProtoNumber(7) @JvmField val praiseFlag: Int = 0,
-        @ProtoNumber(8) @JvmField val msgPraiseUser: List<StrangerInfo>? = null,
+        @ProtoNumber(8) @JvmField val msgPraiseUser: List<StrangerInfo> = emptyList(),
         @ProtoNumber(9) @JvmField val commentCount: Int = 0,
-        @ProtoNumber(10) @JvmField val msgCommentList: List<FeedComment>? = null,
+        @ProtoNumber(10) @JvmField val msgCommentList: List<FeedComment> = emptyList(),
         @ProtoNumber(11) @JvmField val commentRetAll: Int = 0,
         @ProtoNumber(12) @JvmField val hotFlag: Int = 0,
         @ProtoNumber(13) @JvmField val svrReserved: Long = 0L,
@@ -221,12 +221,12 @@ internal class AppointDefine : ProtoBuf {
 
     @Serializable
     internal class HotTopicList(
-        @ProtoNumber(1) @JvmField val topicList: List<HotTopic>? = null
+        @ProtoNumber(1) @JvmField val topicList: List<HotTopic> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class FeedContent(
-        @ProtoNumber(1) @JvmField val strPicUrl: List<String> = listOf(),
+        @ProtoNumber(1) @JvmField val strPicUrl: List<String> = emptyList(),
         @ProtoNumber(2) @JvmField val msgText: RichText? = null,
         @ProtoNumber(3) @JvmField val hrefUrl: String = "",
         @ProtoNumber(5) @JvmField val groupName: String = "",
@@ -254,7 +254,7 @@ internal class AppointDefine : ProtoBuf {
 
     @Serializable
     internal class RecentFreshFeed(
-        @ProtoNumber(1) @JvmField val freshFeedInfo: List<FreshFeedInfo>? = null,
+        @ProtoNumber(1) @JvmField val freshFeedInfo: List<FreshFeedInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val uid: Long = 0L
     ) : ProtoBuf
 
@@ -286,8 +286,8 @@ internal class AppointDefine : ProtoBuf {
     @Serializable
     internal class LBSInfo(
         @ProtoNumber(1) @JvmField val msgGps: GPS? = null,
-        @ProtoNumber(2) @JvmField val msgWifis: List<Wifi>? = null,
-        @ProtoNumber(3) @JvmField val msgCells: List<Cell>? = null
+        @ProtoNumber(2) @JvmField val msgWifis: List<Wifi> = emptyList(),
+        @ProtoNumber(3) @JvmField val msgCells: List<Cell> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -304,10 +304,10 @@ internal class AppointDefine : ProtoBuf {
 
     @Serializable
     internal class FeedsCookie(
-        @ProtoNumber(1) @JvmField val strList: List<String> = listOf(),
+        @ProtoNumber(1) @JvmField val strList: List<String> = emptyList(),
         @ProtoNumber(2) @JvmField val pose: Int = 0,
         @ProtoNumber(3) @JvmField val cookie: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(4) @JvmField val uint64Topics: List<Long>? = null
+        @ProtoNumber(4) @JvmField val uint64Topics: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -386,13 +386,13 @@ internal class AppointDefine : ProtoBuf {
 
     @Serializable
     internal class HotFreshFeedList(
-        @ProtoNumber(1) @JvmField val msgFeeds: List<HotUserFeed>? = null,
+        @ProtoNumber(1) @JvmField val msgFeeds: List<HotUserFeed> = emptyList(),
         @ProtoNumber(2) @JvmField val updateTime: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class RptInterestTag(
-        @ProtoNumber(1) @JvmField val interestTags: List<InterestTag>? = null
+        @ProtoNumber(1) @JvmField val interestTags: List<InterestTag> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -452,8 +452,8 @@ internal class AppointDefine : ProtoBuf {
         @ProtoNumber(1) @JvmField val lableId: Int = 0,
         @ProtoNumber(2) @JvmField val lableMsgPre: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(3) @JvmField val lableMsgLast: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(4) @JvmField val interstName: List<ByteArray>? = null,
-        @ProtoNumber(5) @JvmField val interstType: List<Int>? = null
+        @ProtoNumber(4) @JvmField val interstName: List<ByteArray> = emptyList(),
+        @ProtoNumber(5) @JvmField val interstType: List<Int> = emptyList()
     ) : ProtoBuf
 
     @Serializable

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/FriendListCommon.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/FriendListCommon.kt
@@ -22,10 +22,10 @@ internal class Vec0xd50 : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgUpdateData: List<ExtSnsFrdData>? = null,
+        @ProtoNumber(1) @JvmField val msgUpdateData: List<ExtSnsFrdData> = emptyList(),
         @ProtoNumber(11) @JvmField val over: Int = 0,
         @ProtoNumber(12) @JvmField val nextStart: Int = 0,
-        @ProtoNumber(13) @JvmField val uint64UnfinishedUins: List<Long>? = null
+        @ProtoNumber(13) @JvmField val uint64UnfinishedUins: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -35,7 +35,7 @@ internal class Vec0xd50 : ProtoBuf {
         @ProtoNumber(3) @JvmField val startTime: Int = 0,
         @ProtoNumber(4) @JvmField val startIndex: Int = 0,
         @ProtoNumber(5) @JvmField val reqNum: Int = 0,
-        @ProtoNumber(6) @JvmField val uinList: List<Long>? = null,
+        @ProtoNumber(6) @JvmField val uinList: List<Long> = emptyList(),
         @ProtoNumber(91001) @JvmField val reqMusicSwitch: Int = 0,
         @ProtoNumber(101001) @JvmField val reqMutualmarkAlienation: Int = 0,
         @ProtoNumber(141001) @JvmField val reqMutualmarkScore: Int = 0,
@@ -55,19 +55,19 @@ internal class Vec0xd6b : ProtoBuf {
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val maxPkgSize: Int = 0,
         @ProtoNumber(2) @JvmField val startTime: Int = 0,
-        @ProtoNumber(11) @JvmField val uinList: List<Long>? = null
+        @ProtoNumber(11) @JvmField val uinList: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(11) @JvmField val msgMutualmarkData: List<MutualMarkData>? = null,
-        @ProtoNumber(12) @JvmField val uint64UnfinishedUins: List<Long>? = null
+        @ProtoNumber(11) @JvmField val msgMutualmarkData: List<MutualMarkData> = emptyList(),
+        @ProtoNumber(12) @JvmField val uint64UnfinishedUins: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class MutualMarkData(
         @ProtoNumber(1) @JvmField val frdUin: Long = 0L,
         @ProtoNumber(2) @JvmField val result: Int = 0
-        // @SerialId(11) @JvmField val mutualmarkInfo: List<Mutualmark.MutualMark>? = null
+        // @SerialId(11) @JvmField val mutualmarkInfo: List<Mutualmark.MutualMark> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Group.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Group.kt
@@ -21,7 +21,7 @@ internal class GroupLabel : ProtoBuf {
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val error: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(2) @JvmField val groupInfo: List<GroupInfo>? = null
+        @ProtoNumber(2) @JvmField val groupInfo: List<GroupInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -33,7 +33,7 @@ internal class GroupLabel : ProtoBuf {
     internal class GroupInfo(
         @ProtoNumber(1) @JvmField val int32Result: Int = 0,
         @ProtoNumber(2) @JvmField val groupCode: Long = 0L,
-        @ProtoNumber(3) @JvmField val groupLabel: List<Label>? = null
+        @ProtoNumber(3) @JvmField val groupLabel: List<Label> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -48,7 +48,7 @@ internal class GroupLabel : ProtoBuf {
         @ProtoNumber(1) @JvmField val sourceId: SourceId? = null,
         @ProtoNumber(2) @JvmField val uinInfo: UinInfo? = null,
         @ProtoNumber(3) @JvmField val numberLabel: Int = 5,
-        @ProtoNumber(4) @JvmField val groupCode: List<Long>? = null,
+        @ProtoNumber(4) @JvmField val groupCode: List<Long> = emptyList(),
         @ProtoNumber(5) @JvmField val labelStyle: Int = 0
     ) : ProtoBuf
 

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Highway.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Highway.kt
@@ -44,7 +44,7 @@ internal class BdhExtinfo : ProtoBuf {
     internal class QQVoiceExtRsp(
         @ProtoNumber(1) @JvmField val qid: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(2) @JvmField val int32Retcode: Int = 0,
-        @ProtoNumber(3) @JvmField val msgResult: List<QQVoiceResult>? = null
+        @ProtoNumber(3) @JvmField val msgResult: List<QQVoiceResult> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -84,8 +84,8 @@ internal class BdhExtinfo : ProtoBuf {
         @ProtoNumber(4) @JvmField val groupCode: Long = 0L,
         @ProtoNumber(5) @JvmField val clientType: Int = 0,
         @ProtoNumber(6) @JvmField val msgThumbinfo: PicInfo? = null,
-        @ProtoNumber(7) @JvmField val msgMergeVideoinfo: List<VideoInfo>? = null,
-        @ProtoNumber(8) @JvmField val msgDropVideoinfo: List<VideoInfo>? = null,
+        @ProtoNumber(7) @JvmField val msgMergeVideoinfo: List<VideoInfo> = emptyList(),
+        @ProtoNumber(8) @JvmField val msgDropVideoinfo: List<VideoInfo> = emptyList(),
         @ProtoNumber(9) @JvmField val businessType: Int = 0,
         @ProtoNumber(10) @JvmField val subBusinessType: Int = 0
     ) : ProtoBuf
@@ -225,7 +225,7 @@ internal class CSDataHighwayHead : ProtoBuf {
     @Serializable
     internal class QueryHoleRsp(
         @ProtoNumber(1) @JvmField val result: Int = 0,
-        @ProtoNumber(2) @JvmField val dataHole: List<DataHole>? = null,
+        @ProtoNumber(2) @JvmField val dataHole: List<DataHole> = emptyList(),
         @ProtoNumber(3) @JvmField val boolCompFlag: Boolean = false
     ) : ProtoBuf
 
@@ -279,15 +279,15 @@ internal class HwConfigPersistentPB : ProtoBuf {
     @Serializable
     internal class HwConfigItemPB(
         @ProtoNumber(1) @JvmField val ingKey: String = "",
-        @ProtoNumber(2) @JvmField val endPointList: List<HwEndPointPB>? = null
+        @ProtoNumber(2) @JvmField val endPointList: List<HwEndPointPB> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class HwConfigPB(
-        @ProtoNumber(1) @JvmField val configItemList: List<HwConfigItemPB>? = null,
-        @ProtoNumber(2) @JvmField val netSegConfList: List<HwNetSegConfPB>? = null,
-        @ProtoNumber(3) @JvmField val shortVideoNetConf: List<HwNetSegConfPB>? = null,
-        @ProtoNumber(4) @JvmField val configItemListIp6: List<HwConfigItemPB>? = null
+        @ProtoNumber(1) @JvmField val configItemList: List<HwConfigItemPB> = emptyList(),
+        @ProtoNumber(2) @JvmField val netSegConfList: List<HwNetSegConfPB> = emptyList(),
+        @ProtoNumber(3) @JvmField val shortVideoNetConf: List<HwNetSegConfPB> = emptyList(),
+        @ProtoNumber(4) @JvmField val configItemListIp6: List<HwConfigItemPB> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -335,7 +335,7 @@ internal class Subcmd0x501 : ProtoBuf {
         @ProtoNumber(4) @JvmField val loginSigType: Int = 0,
         @ProtoNumber(5) @JvmField val loginSigTicket: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(6) @JvmField val requestFlag: Int = 0,
-        @ProtoNumber(7) @JvmField val uint32ServiceTypes: List<Int>? = null,
+        @ProtoNumber(7) @JvmField val uint32ServiceTypes: List<Int> = emptyList(),
         @ProtoNumber(8) @JvmField val bid: Int = 0,
         @ProtoNumber(9) @JvmField val term: Int = 0,
         @ProtoNumber(10) @JvmField val plat: Int = 0,
@@ -347,7 +347,7 @@ internal class Subcmd0x501 : ProtoBuf {
     internal class SubCmd0x501Rspbody(
         @ProtoNumber(1) @JvmField val httpconnSigSession: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(2) @JvmField val sessionKey: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(3) @JvmField val msgHttpconnAddrs: List<SrvAddrs>? = null,
+        @ProtoNumber(3) @JvmField val msgHttpconnAddrs: List<SrvAddrs> = emptyList(),
         @ProtoNumber(4) @JvmField val preConnection: Int = 0,
         @ProtoNumber(5) @JvmField val csConn: Int = 0,
         @ProtoNumber(6) @JvmField val msgIpLearnConf: IpLearnConf? = null,
@@ -431,14 +431,14 @@ internal class Subcmd0x501 : ProtoBuf {
         @Serializable
         internal class PTVConf(
             @ProtoNumber(1) @JvmField val channelType: Int = 0,
-            @ProtoNumber(2) @JvmField val msgNetsegconf: List<NetSegConf>? = null,
+            @ProtoNumber(2) @JvmField val msgNetsegconf: List<NetSegConf> = emptyList(),
             @ProtoNumber(3) @JvmField val boolOpenHardwareCodec: Boolean = false
         ) : ProtoBuf
 
         @Serializable
         internal class ShortVideoConf(
             @ProtoNumber(1) @JvmField val channelType: Int = 0,
-            @ProtoNumber(2) @JvmField val msgNetsegconf: List<NetSegConf>? = null,
+            @ProtoNumber(2) @JvmField val msgNetsegconf: List<NetSegConf> = emptyList(),
             @ProtoNumber(3) @JvmField val boolOpenHardwareCodec: Boolean = false,
             @ProtoNumber(4) @JvmField val boolSendAheadSignal: Boolean = false
         ) : ProtoBuf
@@ -446,10 +446,10 @@ internal class Subcmd0x501 : ProtoBuf {
         @Serializable
         internal class SrvAddrs(
             @ProtoNumber(1) @JvmField val serviceType: Int = 0,
-            @ProtoNumber(2) @JvmField val msgAddrs: List<IpAddr>? = null,
+            @ProtoNumber(2) @JvmField val msgAddrs: List<IpAddr> = emptyList(),
             @ProtoNumber(3) @JvmField val fragmentSize: Int = 0,
-            @ProtoNumber(4) @JvmField val msgNetsegconf: List<NetSegConf>? = null,
-            @ProtoNumber(5) @JvmField val msgAddrsV6: List<Ip6Addr>? = null
+            @ProtoNumber(4) @JvmField val msgNetsegconf: List<NetSegConf> = emptyList(),
+            @ProtoNumber(5) @JvmField val msgAddrsV6: List<Ip6Addr> = emptyList()
         ) : ProtoBuf
     }
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/HummerCommelem.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/HummerCommelem.kt
@@ -166,7 +166,7 @@ internal class HummerCommelem : ProtoBuf {
             @ProtoNumber(2) @JvmField val confessorUin: Long = 0L,
             @ProtoNumber(3) @JvmField val confessorSex: Int = 0,
             @ProtoNumber(4) @JvmField val sysmsgFlag: Int = 0,
-            @ProtoNumber(5) @JvmField val confessItems: List<GroupConfessItem>? = null,
+            @ProtoNumber(5) @JvmField val confessItems: List<GroupConfessItem> = emptyList(),
             @ProtoNumber(6) @JvmField val totalTopicCount: Int = 0
         ) : ProtoBuf
     }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/LongMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/LongMsg.kt
@@ -57,17 +57,17 @@ internal class ReqBody(
         @ProtoNumber(1) @JvmField val subcmd: Int = 0,
         @ProtoNumber(2) @JvmField val termType: Int = 0,
         @ProtoNumber(3) @JvmField val platformType: Int = 0,
-        @ProtoNumber(4) @JvmField val msgUpReq: List<LongMsg.MsgUpReq>? = null,
-        @ProtoNumber(5) @JvmField val msgDownReq: List<LongMsg.MsgDownReq>? = null,
-        @ProtoNumber(6) @JvmField val msgDelReq: List<LongMsg.MsgDeleteReq>? = null,
+        @ProtoNumber(4) @JvmField val msgUpReq: List<LongMsg.MsgUpReq> = emptyList(),
+        @ProtoNumber(5) @JvmField val msgDownReq: List<LongMsg.MsgDownReq> = emptyList(),
+        @ProtoNumber(6) @JvmField val msgDelReq: List<LongMsg.MsgDeleteReq> = emptyList(),
         @ProtoNumber(10) @JvmField val agentType: Int = 0
     ) : ProtoBuf
 
     @Serializable
 internal class RspBody(
         @ProtoNumber(1) @JvmField val subcmd: Int = 0,
-        @ProtoNumber(2) @JvmField val msgUpRsp: List<LongMsg.MsgUpRsp>? = null,
-        @ProtoNumber(3) @JvmField val msgDownRsp: List<LongMsg.MsgDownRsp>? = null,
-        @ProtoNumber(4) @JvmField val msgDelRsp: List<LongMsg.MsgDeleteRsp>? = null
+        @ProtoNumber(2) @JvmField val msgUpRsp: List<LongMsg.MsgUpRsp> = emptyList(),
+        @ProtoNumber(3) @JvmField val msgDownRsp: List<LongMsg.MsgDownRsp> = emptyList(),
+        @ProtoNumber(4) @JvmField val msgDelRsp: List<LongMsg.MsgDeleteRsp> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Msg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/Msg.kt
@@ -389,7 +389,7 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(4) @JvmField val pttChangeBit: Int = 0,
         @ProtoNumber(5) @JvmField val vipStatus: Int = 0,
         @ProtoNumber(6) @JvmField val compatibleId: Int = 0,
-        @ProtoNumber(7) @JvmField val insts: List<Inst>? = null,
+        @ProtoNumber(7) @JvmField val insts: List<Inst> = emptyList(),
         @ProtoNumber(8) @JvmField val msgRptCnt: Int = 0,
         @ProtoNumber(9) @JvmField val srcInst: Inst? = null,
         @ProtoNumber(10) @JvmField val longtitude: Int = 0,
@@ -445,7 +445,7 @@ internal class ImMsgBody : ProtoBuf {
 
         @Serializable
         internal class Turntable(
-            @ProtoNumber(1) @JvmField val uint64UinList: List<Long>? = null,
+            @ProtoNumber(1) @JvmField val uint64UinList: List<Long> = emptyList(),
             @ProtoNumber(2) @JvmField val hitUin: Long = 0L,
             @ProtoNumber(3) @JvmField val hitUinNick: String = ""
         )
@@ -611,7 +611,7 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(8) @JvmField val reserved: Int = 0,
         @ProtoNumber(9) @JvmField val subcmd: Int = 0,
         @ProtoNumber(10) @JvmField val microCloud: Int = 0,
-        @ProtoNumber(11) @JvmField val bytesFileUrls: List<ByteArray>? = listOf(),
+        @ProtoNumber(11) @JvmField val bytesFileUrls: List<ByteArray> = emptyList(),
         @ProtoNumber(12) @JvmField val downloadFlag: Int = 0,
         @ProtoNumber(50) @JvmField val dangerEvel: Int = 0,
         @ProtoNumber(51) @JvmField val lifeTime: Int = 0,
@@ -694,8 +694,8 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(2) @JvmField val pcPtlEnd: Int = 0,
         @ProtoNumber(3) @JvmField val macPtlBegin: Int = 0,
         @ProtoNumber(4) @JvmField val macPtlEnd: Int = 0,
-        @ProtoNumber(5) @JvmField val ptlsSupport: List<Int>? = null,
-        @ProtoNumber(6) @JvmField val ptlsNotSupport: List<Int>? = null
+        @ProtoNumber(5) @JvmField val ptlsSupport: List<Int> = emptyList(),
+        @ProtoNumber(6) @JvmField val ptlsNotSupport: List<Int> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -722,7 +722,7 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(20) @JvmField val downPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(29) @JvmField val format: Int = 0,
         @ProtoNumber(30) @JvmField val pbReserve: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(31) @JvmField val bytesPttUrls: List<ByteArray>? = listOf(),
+        @ProtoNumber(31) @JvmField val bytesPttUrls: List<ByteArray> = emptyList(),
         @ProtoNumber(32) @JvmField val downloadFlag: Int = 0
     ) : ProtoBuf
 
@@ -777,7 +777,7 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(17) @JvmField val pcBody: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(18) @JvmField val ingIndex: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(19) @JvmField val redchannel: Int = 0,
-        @ProtoNumber(20) @JvmField val grapUin: List<Long>? = null,
+        @ProtoNumber(20) @JvmField val grapUin: List<Long> = emptyList(),
         @ProtoNumber(21) @JvmField val pbReserve: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -870,11 +870,11 @@ internal class ImMsgBody : ProtoBuf {
 
     @Serializable
     internal class SourceMsg(
-        @ProtoNumber(1) @JvmField val origSeqs: List<Int>? = null,
+        @ProtoNumber(1) @JvmField val origSeqs: List<Int> = emptyList(),
         @ProtoNumber(2) @JvmField val senderUin: Long = 0L,
         @ProtoNumber(3) @JvmField val time: Int = 0,
         @ProtoNumber(4) @JvmField val flag: Int = 0,
-        @ProtoNumber(5) @JvmField val elems: List<Elem>? = null,
+        @ProtoNumber(5) @JvmField val elems: List<Elem> = emptyList(),
         @ProtoNumber(6) @JvmField val type: Int = 0,
         @ProtoNumber(7) @JvmField val richMsg: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(8) @JvmField val pbReserve: ByteArray = EMPTY_BYTE_ARRAY,
@@ -947,8 +947,8 @@ internal class ImMsgBody : ProtoBuf {
         @ProtoNumber(17) @JvmField val fileHeight: Int = 0,
         @ProtoNumber(18) @JvmField val subBusiType: Int = 0,
         @ProtoNumber(19) @JvmField val videoAttr: Int = 0,
-        @ProtoNumber(20) @JvmField val bytesThumbFileUrls: List<ByteArray>? = null,
-        @ProtoNumber(21) @JvmField val bytesVideoFileUrls: List<ByteArray>? = null,
+        @ProtoNumber(20) @JvmField val bytesThumbFileUrls: List<ByteArray> = emptyList(),
+        @ProtoNumber(21) @JvmField val bytesVideoFileUrls: List<ByteArray> = emptyList(),
         @ProtoNumber(22) @JvmField val thumbDownloadFlag: Int = 0,
         @ProtoNumber(23) @JvmField val videoDownloadFlag: Int = 0,
         @ProtoNumber(24) @JvmField val pbReserve: ByteArray = EMPTY_BYTE_ARRAY
@@ -1062,8 +1062,8 @@ internal class ImMsgHead : ProtoBuf {
 
     @Serializable
     internal class InstCtrl(
-        @ProtoNumber(1) @JvmField val msgSendToInst: List<InstInfo>? = listOf(),
-        @ProtoNumber(2) @JvmField val msgExcludeInst: List<InstInfo>? = listOf(),
+        @ProtoNumber(1) @JvmField val msgSendToInst: List<InstInfo> = emptyList(),
+        @ProtoNumber(2) @JvmField val msgExcludeInst: List<InstInfo> = emptyList(),
         @ProtoNumber(3) @JvmField val msgFromInst: InstInfo? = InstInfo()
     ) : ProtoBuf
 
@@ -1171,10 +1171,10 @@ internal class ObjMsg : ProtoBuf {
     internal class ObjMsg(
         @ProtoNumber(1) @JvmField val msgType: Int = 0,
         @ProtoNumber(2) @JvmField val title: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(3) @JvmField val bytesAbstact: List<ByteArray>? = null,
+        @ProtoNumber(3) @JvmField val bytesAbstact: List<ByteArray> = emptyList(),
         @ProtoNumber(5) @JvmField val titleExt: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(6) @JvmField val msgPic: List<MsgPic>? = null,
-        @ProtoNumber(7) @JvmField val msgContentInfo: List<MsgContentInfo>? = null,
+        @ProtoNumber(6) @JvmField val msgPic: List<MsgPic> = emptyList(),
+        @ProtoNumber(7) @JvmField val msgContentInfo: List<MsgContentInfo> = emptyList(),
         @ProtoNumber(8) @JvmField val reportIdShow: Int = 0
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgCommon.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgCommon.kt
@@ -146,7 +146,7 @@ internal class MsgComm : ProtoBuf {
         @ProtoNumber(1) @JvmField val lastReadTime: Int = 0,
         @ProtoNumber(2) @JvmField val peerUin: Long = 0L,
         @ProtoNumber(3) @JvmField val msgCompleted: Int = 0,
-        @ProtoNumber(4) @JvmField val msg: List<Msg>? = null,
+        @ProtoNumber(4) @JvmField val msg: List<Msg> = emptyList(),
         @ProtoNumber(5) @JvmField val unreadMsgNum: Int = 0,
         @ProtoNumber(8) @JvmField val c2cType: Int = 0,
         @ProtoNumber(9) @JvmField val serviceType: Int = 0,

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgRevokeUserDef.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgRevokeUserDef.kt
@@ -9,7 +9,7 @@ internal class MsgRevokeUserDef : ProtoBuf {
     @Serializable
     internal class MsgInfoUserDef(
         @ProtoNumber(1) @JvmField val longMessageFlag: Int = 0,
-        @ProtoNumber(2) @JvmField val longMsgInfo: List<MsgInfoDef>? = null,
+        @ProtoNumber(2) @JvmField val longMsgInfo: List<MsgInfoDef> = emptyList(),
         @ProtoNumber(3) @JvmField val fileUuid: List<String> = listOf()
     ) : ProtoBuf {
         @Serializable
@@ -25,6 +25,6 @@ internal class MsgRevokeUserDef : ProtoBuf {
 internal class UinTypeUserDef(
         @ProtoNumber(1) @JvmField val fromUinType: Int = 0,
         @ProtoNumber(2) @JvmField val fromGroupCode: Long = 0L,
-        @ProtoNumber(3) @JvmField val fileUuid: List<String> = listOf()
+        @ProtoNumber(3) @JvmField val fileUuid: List<String> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgSvc.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgSvc.kt
@@ -20,7 +20,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(2) @JvmField val errmsg: String = "",
         @ProtoNumber(3) @JvmField val syncCookie: ByteArray? = EMPTY_BYTE_ARRAY,
         @ProtoNumber(4) @JvmField val syncFlag: SyncFlag = SyncFlag.CONTINUE,
-        @ProtoNumber(5) @JvmField val uinPairMsgs: List<MsgComm.UinPairMsg>? = null,
+        @ProtoNumber(5) @JvmField val uinPairMsgs: List<MsgComm.UinPairMsg> = emptyList(),
         @ProtoNumber(6) @JvmField val bindUin: Long = 0L,
         @ProtoNumber(7) @JvmField val msgRspType: Int = 0,
         @ProtoNumber(8) @JvmField val pubAccountCookie: ByteArray = EMPTY_BYTE_ARRAY,
@@ -33,7 +33,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(1) @JvmField val subCmd: Int = 0,
         @ProtoNumber(2) @JvmField val groupType: Int = 0,
         @ProtoNumber(3) @JvmField val groupCode: Long = 0L,
-        @ProtoNumber(4) @JvmField val msgList: List<MessageInfo>? = null,
+        @ProtoNumber(4) @JvmField val msgList: List<MessageInfo> = emptyList(),
         @ProtoNumber(5) @JvmField val userdef: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf {
         @Serializable
@@ -132,8 +132,8 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbMsgWithDrawResp(
-        @ProtoNumber(1) @JvmField val c2cWithDraw: List<PbC2CMsgWithDrawResp>? = null,
-        @ProtoNumber(2) @JvmField val groupWithDraw: List<PbGroupMsgWithDrawResp>? = null
+        @ProtoNumber(1) @JvmField val c2cWithDraw: List<PbC2CMsgWithDrawResp> = emptyList(),
+        @ProtoNumber(2) @JvmField val groupWithDraw: List<PbGroupMsgWithDrawResp> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -144,8 +144,8 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbMsgWithDrawReq(
-        @ProtoNumber(1) @JvmField val c2cWithDraw: List<PbC2CMsgWithDrawReq>? = null,
-        @ProtoNumber(2) @JvmField val groupWithDraw: List<PbGroupMsgWithDrawReq>? = null
+        @ProtoNumber(1) @JvmField val c2cWithDraw: List<PbC2CMsgWithDrawReq> = emptyList(),
+        @ProtoNumber(2) @JvmField val groupWithDraw: List<PbGroupMsgWithDrawReq> = emptyList()
     ) : ProtoBuf
 
     internal enum class SyncFlag {
@@ -191,7 +191,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(3) @JvmField val discussUin: Long = 0L,
         @ProtoNumber(4) @JvmField val returnEndSeq: Long = 0L,
         @ProtoNumber(5) @JvmField val returnBeginSeq: Long = 0L,
-        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg>? = null,
+        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg> = emptyList(),
         @ProtoNumber(7) @JvmField val lastGetTime: Long = 0L,
         @ProtoNumber(8) @JvmField val discussInfoSeq: Long = 0L
     ) : ProtoBuf
@@ -212,7 +212,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(3) @JvmField val subCmd: Int = 0,
         @ProtoNumber(4) @JvmField val groupType: Int = 0,
         @ProtoNumber(5) @JvmField val groupCode: Long = 0L,
-        @ProtoNumber(6) @JvmField val failedMsgList: List<MessageResult>? = null,
+        @ProtoNumber(6) @JvmField val failedMsgList: List<MessageResult> = emptyList(),
         @ProtoNumber(7) @JvmField val userdef: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf {
         @Serializable
@@ -238,7 +238,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbC2CMsgWithDrawReq(
-        @ProtoNumber(1) @JvmField val msgInfo: List<MsgInfo>? = null,
+        @ProtoNumber(1) @JvmField val msgInfo: List<MsgInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val longMessageFlag: Int = 0,
         @ProtoNumber(3) @JvmField val reserved: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(4) @JvmField val subCmd: Int = 0
@@ -282,7 +282,7 @@ internal class MsgSvc : ProtoBuf {
     internal class PbPullGroupMsgSeqResp(
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val errmsg: String = "",
-        @ProtoNumber(3) @JvmField val groupInfoResp: List<GroupInfoResp>? = null
+        @ProtoNumber(3) @JvmField val groupInfoResp: List<GroupInfoResp> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class GroupInfoResp(
@@ -324,7 +324,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbSearchRoamMsgInCloudResp(
-        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg>? = null,
+        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg> = emptyList(),
         @ProtoNumber(2) @JvmField val serializeRspbody: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -340,7 +340,7 @@ internal class MsgSvc : ProtoBuf {
     @Serializable
     internal class PbUnReadMsgSeqResp(
         @ProtoNumber(1) @JvmField val c2cUnreadInfo: PbC2CUnReadMsgNumResp? = null,
-        @ProtoNumber(2) @JvmField val binduinUnreadInfo: List<PbBindUinUnReadMsgNumResp>? = null,
+        @ProtoNumber(2) @JvmField val binduinUnreadInfo: List<PbBindUinUnReadMsgNumResp> = emptyList(),
         @ProtoNumber(3) @JvmField val groupUnreadInfo: PbPullGroupMsgSeqResp? = null,
         @ProtoNumber(4) @JvmField val discussUnreadInfo: PbPullDiscussMsgSeqResp? = null,
         @ProtoNumber(5) @JvmField val thirdqqUnreadInfo: PbThirdQQUnReadMsgNumResp? = null
@@ -348,7 +348,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbDeleteMsgReq(
-        @ProtoNumber(1) @JvmField val msgItems: List<MsgItem>? = null
+        @ProtoNumber(1) @JvmField val msgItems: List<MsgItem> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class MsgItem(
@@ -363,7 +363,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class MultiMsgAssist(
-        @ProtoNumber(1) @JvmField val repeatedRouting: List<RoutingHead>? = null,
+        @ProtoNumber(1) @JvmField val repeatedRouting: List<RoutingHead> = emptyList(),
         @ProtoNumber(2) @JvmField val msgUse: Int /* enum */ = 1,
         @ProtoNumber(3) @JvmField val tempId: Long = 0L,
         @ProtoNumber(4) @JvmField val vedioLen: Long = 0L,
@@ -375,8 +375,8 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbMsgReadedReportReq(
-        @ProtoNumber(1) @JvmField val grpReadReport: List<PbGroupReadedReportReq>? = null,
-        @ProtoNumber(2) @JvmField val disReadReport: List<PbDiscussReadedReportReq>? = null,
+        @ProtoNumber(1) @JvmField val grpReadReport: List<PbGroupReadedReportReq> = emptyList(),
+        @ProtoNumber(2) @JvmField val disReadReport: List<PbDiscussReadedReportReq> = emptyList(),
         @ProtoNumber(3) @JvmField val c2cReadReport: PbC2CReadedReportReq? = null,
         @ProtoNumber(4) @JvmField val bindUinReadReport: PbBindUinMsgReadedConfirmReq? = null
     ) : ProtoBuf
@@ -388,7 +388,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(3) @JvmField val peerUin: Long = 0L,
         @ProtoNumber(4) @JvmField val lastMsgtime: Long = 0L,
         @ProtoNumber(5) @JvmField val random: Long = 0L,
-        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg>? = null,
+        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg> = emptyList(),
         @ProtoNumber(7) @JvmField val iscomplete: Int = 0
     ) : ProtoBuf
 
@@ -483,7 +483,7 @@ internal class MsgSvc : ProtoBuf {
     internal class PbC2CMsgWithDrawResp(
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val errmsg: String = "",
-        @ProtoNumber(3) @JvmField val msgStatus: List<MsgStatus>? = null,
+        @ProtoNumber(3) @JvmField val msgStatus: List<MsgStatus> = emptyList(),
         @ProtoNumber(4) @JvmField val subCmd: Int = 0
     ) : ProtoBuf {
         @Serializable
@@ -521,8 +521,8 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbMsgReadedReportResp(
-        @ProtoNumber(1) @JvmField val grpReadReport: List<PbGroupReadedReportResp>? = null,
-        @ProtoNumber(2) @JvmField val disReadReport: List<PbDiscussReadedReportResp>? = null,
+        @ProtoNumber(1) @JvmField val grpReadReport: List<PbGroupReadedReportResp> = emptyList(),
+        @ProtoNumber(2) @JvmField val disReadReport: List<PbDiscussReadedReportResp> = emptyList(),
         @ProtoNumber(3) @JvmField val c2cReadReport: PbC2CReadedReportResp? = null,
         @ProtoNumber(4) @JvmField val bindUinReadReport: PbBindUinMsgReadedConfirmResp? = null
     ) : ProtoBuf
@@ -531,7 +531,7 @@ internal class MsgSvc : ProtoBuf {
     internal class PbThirdQQUnReadMsgNumResp(
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val errmsg: String = "",
-        @ProtoNumber(3) @JvmField val thirdqqRespInfo: List<ThirdQQRespInfo>? = null,
+        @ProtoNumber(3) @JvmField val thirdqqRespInfo: List<ThirdQQRespInfo> = emptyList(),
         @ProtoNumber(4) @JvmField val interval: Int = 0
     ) : ProtoBuf {
         @Serializable
@@ -589,7 +589,7 @@ internal class MsgSvc : ProtoBuf {
     @Serializable
     internal class PbUnReadMsgSeqReq(
         @ProtoNumber(1) @JvmField val c2cUnreadInfo: PbC2CUnReadMsgNumReq? = null,
-        @ProtoNumber(2) @JvmField val binduinUnreadInfo: List<PbBindUinUnReadMsgNumReq>? = null,
+        @ProtoNumber(2) @JvmField val binduinUnreadInfo: List<PbBindUinUnReadMsgNumReq> = emptyList(),
         @ProtoNumber(3) @JvmField val groupUnreadInfo: PbPullGroupMsgSeqReq? = null,
         @ProtoNumber(4) @JvmField val discussUnreadInfo: PbPullDiscussMsgSeqReq? = null,
         @ProtoNumber(5) @JvmField val thirdqqUnreadInfo: PbThirdQQUnReadMsgNumReq? = null
@@ -599,7 +599,7 @@ internal class MsgSvc : ProtoBuf {
     internal class PbPullDiscussMsgSeqResp(
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val errmsg: String = "",
-        @ProtoNumber(3) @JvmField val discussInfoResp: List<DiscussInfoResp>? = null
+        @ProtoNumber(3) @JvmField val discussInfoResp: List<DiscussInfoResp> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class DiscussInfoResp(
@@ -611,7 +611,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbPullDiscussMsgSeqReq(
-        @ProtoNumber(1) @JvmField val discussInfoReq: List<DiscussInfoReq>? = null
+        @ProtoNumber(1) @JvmField val discussInfoReq: List<DiscussInfoReq> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class DiscussInfoReq(
@@ -647,7 +647,7 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(3) @JvmField val peerUin: Long = 0L,
         @ProtoNumber(4) @JvmField val lastMsgtime: Long = 0L,
         @ProtoNumber(5) @JvmField val random: Long = 0L,
-        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg>? = null,
+        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg> = emptyList(),
         @ProtoNumber(7) @JvmField val sig: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -660,7 +660,7 @@ internal class MsgSvc : ProtoBuf {
     @Serializable
     internal class PbC2CReadedReportReq(
         @ProtoNumber(1) @JvmField val syncCookie: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(2) @JvmField val pairInfo: List<UinPairReadInfo>? = null
+        @ProtoNumber(2) @JvmField val pairInfo: List<UinPairReadInfo> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class UinPairReadInfo(
@@ -700,7 +700,7 @@ internal class MsgSvc : ProtoBuf {
 
     @Serializable
     internal class PbPullGroupMsgSeqReq(
-        @ProtoNumber(1) @JvmField val groupInfoReq: List<GroupInfoReq>? = null
+        @ProtoNumber(1) @JvmField val groupInfoReq: List<GroupInfoReq> = emptyList()
     ) : ProtoBuf {
         @Serializable
         internal class GroupInfoReq(
@@ -732,12 +732,12 @@ internal class MsgSvc : ProtoBuf {
         @ProtoNumber(3) @JvmField val groupCode: Long = 0L,
         @ProtoNumber(4) @JvmField val returnBeginSeq: Long = 0L,
         @ProtoNumber(5) @JvmField val returnEndSeq: Long = 0L,
-        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg>? = null
+        @ProtoNumber(6) @JvmField val msg: List<MsgComm.Msg> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class PbThirdQQUnReadMsgNumReq(
-        @ProtoNumber(1) @JvmField val thirdqqReqInfo: List<ThirdQQReqInfo>? = null,
+        @ProtoNumber(1) @JvmField val thirdqqReqInfo: List<ThirdQQReqInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val source: Int = 0
     ) : ProtoBuf {
         @Serializable

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgTransmit.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MsgTransmit.kt
@@ -15,12 +15,12 @@ internal class PbMultiMsgItem(
 
     @Serializable
 internal class PbMultiMsgNew(
-        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg>? = null
+        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg> = emptyList()
     ) : ProtoBuf
 
     @Serializable
 internal class PbMultiMsgTransmit(
-        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg>? = null,
-        @ProtoNumber(2) @JvmField val pbItemList: List<MsgTransmit.PbMultiMsgItem>? = null
+        @ProtoNumber(1) @JvmField val msg: List<MsgComm.Msg> = emptyList(),
+        @ProtoNumber(2) @JvmField val pbItemList: List<MsgTransmit.PbMultiMsgItem> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MultiMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/MultiMsg.kt
@@ -25,12 +25,12 @@ internal class MultiMsg : ProtoBuf {
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val thumbDownPara: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(3) @JvmField val msgKey: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(4) @JvmField val uint32DownIp: List<Int>? = null,
-        @ProtoNumber(5) @JvmField val uint32DownPort: List<Int>? = null,
+        @ProtoNumber(4) @JvmField val uint32DownIp: List<Int> = emptyList(),
+        @ProtoNumber(5) @JvmField val uint32DownPort: List<Int> = emptyList(),
         @ProtoNumber(6) @JvmField val msgResid: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(7) @JvmField val msgExternInfo: ExternMsg? = null,
-        @ProtoNumber(8) @JvmField val bytesDownIpV6: List<ByteArray>? = null,
-        @ProtoNumber(9) @JvmField val uint32DownV6Port: List<Int>? = null
+        @ProtoNumber(8) @JvmField val bytesDownIpV6: List<ByteArray> = emptyList(),
+        @ProtoNumber(9) @JvmField val uint32DownV6Port: List<Int> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -47,16 +47,16 @@ internal class MultiMsg : ProtoBuf {
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val msgResid: String = "",
         @ProtoNumber(3) @JvmField val msgUkey: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(4) @JvmField val uint32UpIp: List<Int> = listOf(),
-        @ProtoNumber(5) @JvmField val uint32UpPort: List<Int> = listOf(),
+        @ProtoNumber(4) @JvmField val uint32UpIp: List<Int> = emptyList(),
+        @ProtoNumber(5) @JvmField val uint32UpPort: List<Int> = emptyList(),
         @ProtoNumber(6) @JvmField val blockSize: Long = 0L,
         @ProtoNumber(7) @JvmField val upOffset: Long = 0L,
         @ProtoNumber(8) @JvmField val applyId: Int = 0,
         @ProtoNumber(9) @JvmField val msgKey: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(10) @JvmField val msgSig: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(11) @JvmField val msgExternInfo: ExternMsg? = null,
-        @ProtoNumber(12) @JvmField val bytesUpIpV6: List<ByteArray>? = null,
-        @ProtoNumber(13) @JvmField val uint32UpV6Port: List<Int>? = null
+        @ProtoNumber(12) @JvmField val bytesUpIpV6: List<ByteArray> = emptyList(),
+        @ProtoNumber(13) @JvmField val uint32UpV6Port: List<Int> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -66,8 +66,8 @@ internal class MultiMsg : ProtoBuf {
         @ProtoNumber(3) @JvmField val platformType: Int = 0,
         @ProtoNumber(4) @JvmField val netType: Int = 0,
         @ProtoNumber(5) @JvmField val buildVer: String = "",
-        @ProtoNumber(6) @JvmField val multimsgApplyupReq: List<MultiMsg.MultiMsgApplyUpReq>? = null,
-        @ProtoNumber(7) @JvmField val multimsgApplydownReq: List<MultiMsg.MultiMsgApplyDownReq>? = null,
+        @ProtoNumber(6) @JvmField val multimsgApplyupReq: List<MultiMsg.MultiMsgApplyUpReq> = emptyList(),
+        @ProtoNumber(7) @JvmField val multimsgApplydownReq: List<MultiMsg.MultiMsgApplyDownReq> = emptyList(),
         @ProtoNumber(8) @JvmField val buType: Int = 0,
         @ProtoNumber(9) @JvmField val reqChannelType: Int = 0
     ) : ProtoBuf
@@ -75,7 +75,7 @@ internal class MultiMsg : ProtoBuf {
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val subcmd: Int = 0,
-        @ProtoNumber(2) @JvmField val multimsgApplyupRsp: List<MultiMsg.MultiMsgApplyUpRsp>? = null,
-        @ProtoNumber(3) @JvmField val multimsgApplydownRsp: List<MultiMsg.MultiMsgApplyDownRsp>? = null
+        @ProtoNumber(2) @JvmField val multimsgApplyupRsp: List<MultiMsg.MultiMsgApplyUpRsp> = emptyList(),
+        @ProtoNumber(3) @JvmField val multimsgApplydownRsp: List<MultiMsg.MultiMsgApplyDownRsp> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/OIDB.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/OIDB.kt
@@ -11,7 +11,7 @@ internal class Oidb0x8a0 : ProtoBuf {
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val optUint64GroupCode: Long = 0L,
-        @ProtoNumber(2) @JvmField val msgKickResult: List<KickResult>? = null
+        @ProtoNumber(2) @JvmField val msgKickResult: List<KickResult> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -31,8 +31,8 @@ internal class Oidb0x8a0 : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val optUint64GroupCode: Long = 0L,
-        @ProtoNumber(2) @JvmField val msgKickList: List<KickMemberInfo>? = null,
-        @ProtoNumber(3) @JvmField val kickList: List<Long>? = null,
+        @ProtoNumber(2) @JvmField val msgKickList: List<KickMemberInfo> = emptyList(),
+        @ProtoNumber(3) @JvmField val kickList: List<Long> = emptyList(),
         @ProtoNumber(4) @JvmField val kickFlag: Int = 0,
         @ProtoNumber(5) @JvmField val kickMsg: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
@@ -49,15 +49,15 @@ internal class Oidb0x8fc : ProtoBuf {
 
     @Serializable
     internal class CommCardNameBuf(
-        @ProtoNumber(1) @JvmField val richCardName: List<RichCardNameElem>? = null
+        @ProtoNumber(1) @JvmField val richCardName: List<RichCardNameElem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val groupCode: Long = 0L,
         @ProtoNumber(2) @JvmField val showFlag: Int = 0,
-        @ProtoNumber(3) @JvmField val memLevelInfo: List<MemberInfo>? = null,
-        @ProtoNumber(4) @JvmField val levelName: List<LevelName>? = null,
+        @ProtoNumber(3) @JvmField val memLevelInfo: List<MemberInfo> = emptyList(),
+        @ProtoNumber(4) @JvmField val levelName: List<LevelName> = emptyList(),
         @ProtoNumber(5) @JvmField val updateTime: Int = 0,
         @ProtoNumber(6) @JvmField val officeMode: Int = 0,
         @ProtoNumber(7) @JvmField val groupOpenAppid: Int = 0,
@@ -82,7 +82,7 @@ internal class Oidb0x8fc : ProtoBuf {
         @ProtoNumber(13) @JvmField val job: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(14) @JvmField val tribeLevel: Int = 0,
         @ProtoNumber(15) @JvmField val tribePoint: Int = 0,
-        @ProtoNumber(16) @JvmField val richCardName: List<CardNameElem>? = null,
+        @ProtoNumber(16) @JvmField val richCardName: List<CardNameElem> = emptyList(),
         @ProtoNumber(17) @JvmField val commRichCardName: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -176,7 +176,7 @@ internal class Oidb0x88d : ProtoBuf {
         @ProtoNumber(16) @JvmField val groupMemo: String? = null,
         @ProtoNumber(17) @JvmField val ingGroupFingerMemo: String? = null,
         @ProtoNumber(18) @JvmField val ingGroupClassText: String? = null,
-        @ProtoNumber(19) @JvmField val groupAllianceCode: List<Int>? = null,
+        @ProtoNumber(19) @JvmField val groupAllianceCode: List<Int> = emptyList(),
         @ProtoNumber(20) @JvmField val groupExtraAdmNum: Int? = null,
         @ProtoNumber(21) @JvmField val groupUin: Long? = null,
         @ProtoNumber(22) @JvmField val groupCurMsgSeq: Int? = null,
@@ -198,7 +198,7 @@ internal class Oidb0x88d : ProtoBuf {
         @ProtoNumber(38) @JvmField val certificationType: Int? = null,
         @ProtoNumber(39) @JvmField val ingCertificationText: String? = null,
         @ProtoNumber(40) @JvmField val ingGroupRichFingerMemo: String? = null,
-        @ProtoNumber(41) @JvmField val tagRecord: List<TagRecord>? = null,
+        @ProtoNumber(41) @JvmField val tagRecord: List<TagRecord> = emptyList(),
         @ProtoNumber(42) @JvmField val groupGeoInfo: GroupGeoInfo? = null,
         @ProtoNumber(43) @JvmField val headPortraitSeq: Int? = null,
         @ProtoNumber(44) @JvmField val msgHeadPortrait: GroupHeadPortrait? = null,
@@ -271,24 +271,24 @@ internal class Oidb0x88d : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val stzrspgroupinfo: List<RspGroupInfo>? = null,
+        @ProtoNumber(1) @JvmField val stzrspgroupinfo: List<RspGroupInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val errorinfo: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val appid: Int = 0,
-        @ProtoNumber(2) @JvmField val stzreqgroupinfo: List<ReqGroupInfo>? = null,
+        @ProtoNumber(2) @JvmField val stzreqgroupinfo: List<ReqGroupInfo> = emptyList(),
         @ProtoNumber(3) @JvmField val pcClientVersion: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class GroupHeadPortrait(
         @ProtoNumber(1) @JvmField val picCnt: Int = 0,
-        @ProtoNumber(2) @JvmField val msgInfo: List<GroupHeadPortraitInfo>? = null,
+        @ProtoNumber(2) @JvmField val msgInfo: List<GroupHeadPortraitInfo> = emptyList(),
         @ProtoNumber(3) @JvmField val defaultId: Int = 0,
         @ProtoNumber(4) @JvmField val verifyingPicCnt: Int = 0,
-        @ProtoNumber(5) @JvmField val msgVerifyingpicInfo: List<GroupHeadPortraitInfo>? = null
+        @ProtoNumber(5) @JvmField val msgVerifyingpicInfo: List<GroupHeadPortraitInfo> = emptyList()
     ) : ProtoBuf
 }
 
@@ -320,7 +320,7 @@ internal class Oidb0x89a : ProtoBuf {
         @ProtoNumber(16) @JvmField val addOption: Int? = null,
         @ProtoNumber(17) @JvmField val shutupTime: Int? = null,
         @ProtoNumber(18) @JvmField val groupTypeFlag: Int? = null,
-        @ProtoNumber(19) @JvmField val stringGroupTag: List<ByteArray>? = null,
+        @ProtoNumber(19) @JvmField val stringGroupTag: List<ByteArray> = emptyList(),
         @ProtoNumber(20) @JvmField val msgGroupGeoInfo: GroupGeoInfo? = null,
         @ProtoNumber(21) @JvmField val groupClassExt: Int? = null,
         @ProtoNumber(22) @JvmField val ingGroupClassText: ByteArray? = null,
@@ -384,13 +384,13 @@ internal class Cmd0x7cb : ProtoBuf {
     internal class RspBody(
         @ProtoNumber(1) @JvmField val timeStamp: Int = 0,
         @ProtoNumber(2) @JvmField val timeGap: Int = 0,
-        @ProtoNumber(3) @JvmField val commentConfigs: List<CommentConfig>? = null,
+        @ProtoNumber(3) @JvmField val commentConfigs: List<CommentConfig> = emptyList(),
         @ProtoNumber(4) @JvmField val attendTipsToA: String = "",
         @ProtoNumber(5) @JvmField val firstMsgTips: String = "",
-        @ProtoNumber(6) @JvmField val cancleConfig: List<ConfigItem>? = null,
+        @ProtoNumber(6) @JvmField val cancleConfig: List<ConfigItem> = emptyList(),
         @ProtoNumber(7) @JvmField val msgDateRequest: DateRequest? = null,
-        @ProtoNumber(8) @JvmField val msgHotLocale: List<ByteArray>? = null,//List<AppointDefine.LocaleInfo>
-        @ProtoNumber(9) @JvmField val msgTopicList: List<TopicConfig>? = null,
+        @ProtoNumber(8) @JvmField val msgHotLocale: List<ByteArray> = emptyList(),//List<AppointDefine.LocaleInfo>
+        @ProtoNumber(9) @JvmField val msgTopicList: List<TopicConfig> = emptyList(),
         @ProtoNumber(10) @JvmField val travelMsgTips: String = "",
         @ProtoNumber(11) @JvmField val travelProfileTips: String = "",
         @ProtoNumber(12) @JvmField val travelAttenTips: String = "",
@@ -400,7 +400,7 @@ internal class Cmd0x7cb : ProtoBuf {
     @Serializable
     internal class CommentConfig(
         @ProtoNumber(1) @JvmField val appointSubject: Int = 0,
-        @ProtoNumber(2) @JvmField val msgConfigs: List<ConfigItem>? = null
+        @ProtoNumber(2) @JvmField val msgConfigs: List<ConfigItem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -461,7 +461,7 @@ internal class GroupAppPb : ProtoBuf {
     @Serializable
     internal class AppList(
         @ProtoNumber(1) @JvmField val hash: String = "",
-        @ProtoNumber(2) @JvmField val infos: List<AppInfo>? = null
+        @ProtoNumber(2) @JvmField val infos: List<AppInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -507,7 +507,7 @@ internal class Cmd0x5fd : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgComment: List<AppointDefine.DateComment>? = null,
+        @ProtoNumber(1) @JvmField val msgComment: List<AppointDefine.DateComment> = emptyList(),
         @ProtoNumber(2) @JvmField val errorTips: String = "",
         @ProtoNumber(3) @JvmField val clearCacheFlag: Int = 0,
         @ProtoNumber(4) @JvmField val commentWording: String = "",
@@ -533,7 +533,7 @@ internal class Oidb0xbcb : ProtoBuf {
 
     @Serializable
     internal class CheckUrlRsp(
-        @ProtoNumber(1) @JvmField val results: List<UrlCheckResult>? = null,
+        @ProtoNumber(1) @JvmField val results: List<UrlCheckResult> = emptyList(),
         @ProtoNumber(2) @JvmField val nextReqDuration: Int = 0
     ) : ProtoBuf
 
@@ -551,7 +551,7 @@ internal class Oidb0xbcb : ProtoBuf {
 
     @Serializable
     internal class CheckUrlReq(
-        @ProtoNumber(1) @JvmField val url: List<String> = listOf(),
+        @ProtoNumber(1) @JvmField val url: List<String> = emptyList(),
         @ProtoNumber(2) @JvmField val refer: String = "",
         @ProtoNumber(3) @JvmField val plateform: String = "",
         @ProtoNumber(4) @JvmField val qqPfTo: String = "",
@@ -616,7 +616,7 @@ internal class Oidb0xbe8 : ProtoBuf {
         @ProtoNumber(3) @JvmField val reqOfPopupFlag: Int = 0,
         @ProtoNumber(4) @JvmField val rstOfPopupFlag: Int = 0,
         @ProtoNumber(5) @JvmField val mqq808WelcomepageFlag: Int = 0,
-        @ProtoNumber(6) @JvmField val msgPopupResult: List<PopupResult>? = null
+        @ProtoNumber(6) @JvmField val msgPopupResult: List<PopupResult> = emptyList()
     ) : ProtoBuf
 }
 
@@ -626,13 +626,13 @@ internal class Cmd0x7de : ProtoBuf {
     internal class UserProfile(
         @ProtoNumber(1) @JvmField val msgPublisherInfo: AppointDefine.PublisherInfo? = null,
         @ProtoNumber(2) @JvmField val msgAppointsInfo: AppointDefine.AppointInfo? = null,
-        @ProtoNumber(3) @JvmField val msgVistorInfo: List<AppointDefine.StrangerInfo>? = null
+        @ProtoNumber(3) @JvmField val msgVistorInfo: List<AppointDefine.StrangerInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val msgHead: BusiRespHead? = null,
-        @ProtoNumber(2) @JvmField val msgUserList: List<UserProfile>? = null,
+        @ProtoNumber(2) @JvmField val msgUserList: List<UserProfile> = emptyList(),
         @ProtoNumber(3) @JvmField val ended: Int = 0,
         @ProtoNumber(4) @JvmField val cookie: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
@@ -675,7 +675,7 @@ internal class Cmd0x7a8 : ProtoBuf {
         @ProtoNumber(12) @JvmField val readReport: Int = 0,
         @ProtoNumber(13) @JvmField val sortType: Int = 0,
         @ProtoNumber(14) @JvmField val onlyNew: Int = 0,
-        @ProtoNumber(15) @JvmField val filterMedalIds: List<Int>? = null,
+        @ProtoNumber(15) @JvmField val filterMedalIds: List<Int> = emptyList(),
         @ProtoNumber(16) @JvmField val onlySummary: Int = 0,
         @ProtoNumber(17) @JvmField val doScan: Int = 0,
         @ProtoNumber(18) @JvmField val startTimestamp: Int = 0
@@ -688,7 +688,7 @@ internal class Cmd0x7a8 : ProtoBuf {
         @ProtoNumber(3) @JvmField val friCount: Int = 0,
         @ProtoNumber(4) @JvmField val metalCount: Int = 0,
         @ProtoNumber(5) @JvmField val metalTotal: Int = 0,
-        @ProtoNumber(6) @JvmField val msgMedal: List<Common.MedalInfo>? = null,
+        @ProtoNumber(6) @JvmField val msgMedal: List<Common.MedalInfo> = emptyList(),
         @ProtoNumber(8) @JvmField val totalPoint: Int = 0,
         @ProtoNumber(9) @JvmField val int32NewCount: Int = 0,
         @ProtoNumber(10) @JvmField val int32UpgradeCount: Int = 0,
@@ -717,7 +717,7 @@ internal class Cmd0x5fe : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgComment: List<AppointDefine.DateComment>? = null,
+        @ProtoNumber(1) @JvmField val msgComment: List<AppointDefine.DateComment> = emptyList(),
         @ProtoNumber(2) @JvmField val errorTips: String = "",
         @ProtoNumber(3) @JvmField val fetchOldOver: Int = 0,
         @ProtoNumber(4) @JvmField val fetchNewOver: Int = 0
@@ -732,7 +732,7 @@ internal class Oidb0xc35 : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val uin: Long = 0L,
-        @ProtoNumber(2) @JvmField val msgExposeInfo: List<ExposeItem>? = null
+        @ProtoNumber(2) @JvmField val msgExposeInfo: List<ExposeItem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -806,8 +806,8 @@ internal class Cmd0xccb : ProtoBuf {
         @ProtoNumber(1) @JvmField val type: Int = 0,
         @ProtoNumber(2) @JvmField val destUin: Long = 0L,
         @ProtoNumber(3) @JvmField val groupCode: Long = 0L,
-        @ProtoNumber(4) @JvmField val c2cMsg: List<C2cMsgInfo>? = null,
-        @ProtoNumber(5) @JvmField val groupMsg: List<GroupMsgInfo>? = null
+        @ProtoNumber(4) @JvmField val c2cMsg: List<C2cMsgInfo> = emptyList(),
+        @ProtoNumber(5) @JvmField val groupMsg: List<GroupMsgInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -815,8 +815,8 @@ internal class Cmd0xccb : ProtoBuf {
         @ProtoNumber(1) @JvmField val type: Int = 0,
         @ProtoNumber(2) @JvmField val destUin: Long = 0L,
         @ProtoNumber(3) @JvmField val groupCode: Long = 0L,
-        @ProtoNumber(4) @JvmField val c2cMsg: List<C2cMsgInfo>? = null,
-        @ProtoNumber(5) @JvmField val groupMsg: List<GroupMsgInfo>? = null,
+        @ProtoNumber(4) @JvmField val c2cMsg: List<C2cMsgInfo> = emptyList(),
+        @ProtoNumber(5) @JvmField val groupMsg: List<GroupMsgInfo> = emptyList(),
         @ProtoNumber(6) @JvmField val resId: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -892,16 +892,16 @@ internal class Oidb0x5e1 : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(11) @JvmField val msgUinData: List<UdcUinData>? = null,
-        @ProtoNumber(12) @JvmField val uint64UnfinishedUins: List<Long>? = null
+        @ProtoNumber(11) @JvmField val msgUinData: List<UdcUinData> = emptyList(),
+        @ProtoNumber(12) @JvmField val uint64UnfinishedUins: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val uint64Uins: List<Long>? = null,
+        @ProtoNumber(1) @JvmField val uint64Uins: List<Long> = emptyList(),
         @ProtoNumber(2) @JvmField val startTime: Int = 0,
         @ProtoNumber(3) @JvmField val maxPackageSize: Int = 0,
-        @ProtoNumber(4) @JvmField val bytesOpenid: List<ByteArray>? = null,
+        @ProtoNumber(4) @JvmField val bytesOpenid: List<ByteArray> = emptyList(),
         @ProtoNumber(5) @JvmField val appid: Int = 0,
         @ProtoNumber(20002) @JvmField val reqNick: Int = 0,
         @ProtoNumber(20003) @JvmField val reqCountry: Int = 0,
@@ -950,20 +950,20 @@ internal class Oidb0x5e1 : ProtoBuf {
 internal class Oidb0xc90 : ProtoBuf {
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val communityBid: List<Long>? = null,
+        @ProtoNumber(1) @JvmField val communityBid: List<Long> = emptyList(),
         @ProtoNumber(2) @JvmField val page: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class CommunityWebInfo(
-        @ProtoNumber(1) @JvmField val communityInfoItem: List<CommunityConfigInfo>? = null,
+        @ProtoNumber(1) @JvmField val communityInfoItem: List<CommunityConfigInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val page: Int = 0,
         @ProtoNumber(3) @JvmField val end: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val communityInfoItem: List<CommunityConfigInfo>? = null,
+        @ProtoNumber(1) @JvmField val communityInfoItem: List<CommunityConfigInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val jumpConcernCommunityUrl: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(3) @JvmField val communityTitleWording: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(4) @JvmField val moreUrlWording: ByteArray = EMPTY_BYTE_ARRAY,
@@ -1055,7 +1055,7 @@ internal class Cmd0x7dc : ProtoBuf {
     internal class RspBody(
         @ProtoNumber(1) @JvmField val seq: Int = 0,
         @ProtoNumber(2) @JvmField val wording: String = "",
-        @ProtoNumber(3) @JvmField val msgAppointInfo: List<AppointDefine.AppointInfo>? = null
+        @ProtoNumber(3) @JvmField val msgAppointInfo: List<AppointDefine.AppointInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1080,7 +1080,7 @@ internal class Cmd0x7cd : ProtoBuf {
         @ProtoNumber(1) @JvmField val stamp: Int = 0,
         @ProtoNumber(2) @JvmField val over: Int = 0,
         @ProtoNumber(3) @JvmField val next: Int = 0,
-        @ProtoNumber(4) @JvmField val msgAppointsInfo: List<AppointBrife>? = null
+        @ProtoNumber(4) @JvmField val msgAppointsInfo: List<AppointBrife> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1089,7 +1089,7 @@ internal class Cmd0x7cd : ProtoBuf {
         @ProtoNumber(2) @JvmField val start: Int = 0,
         @ProtoNumber(3) @JvmField val want: Int = 0,
         @ProtoNumber(4) @JvmField val msgLbsInfo: AppointDefine.LBSInfo? = null,
-        @ProtoNumber(5) @JvmField val msgAppointIds: List<AppointDefine.AppointID>? = null,
+        @ProtoNumber(5) @JvmField val msgAppointIds: List<AppointDefine.AppointID> = emptyList(),
         @ProtoNumber(6) @JvmField val appointOperation: Int = 0,
         @ProtoNumber(100) @JvmField val requestUin: Long = 0L
     ) : ProtoBuf
@@ -1272,9 +1272,9 @@ internal class Oidb0xb60 : ProtoBuf {
 
     @Serializable
     internal class GetPrivilegeRsp(
-        @ProtoNumber(1) @JvmField val apiGroups: List<Int>? = null,
+        @ProtoNumber(1) @JvmField val apiGroups: List<Int> = emptyList(),
         @ProtoNumber(2) @JvmField val nextReqDuration: Int = 0,
-        @ProtoNumber(3) @JvmField val apiNames: List<String> = listOf()
+        @ProtoNumber(3) @JvmField val apiNames: List<String> = emptyList()
     ) : ProtoBuf
 }
 
@@ -1295,12 +1295,12 @@ internal class Cmd0x5fc : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgEventList: List<AppointDefine.DateEvent>? = null,
-        @ProtoNumber(2) @JvmField val actAppointIds: List<AppointDefine.AppointID>? = null,
+        @ProtoNumber(1) @JvmField val msgEventList: List<AppointDefine.DateEvent> = emptyList(),
+        @ProtoNumber(2) @JvmField val actAppointIds: List<AppointDefine.AppointID> = emptyList(),
         @ProtoNumber(3) @JvmField val maxEventId: Long = 0L,
         @ProtoNumber(4) @JvmField val errorTips: String = "",
-        @ProtoNumber(5) @JvmField val msgNearbyEventList: List<AppointDefine.NearbyEvent>? = null,
-        @ProtoNumber(6) @JvmField val msgFeedEventList: List<AppointDefine.FeedEvent>? = null,
+        @ProtoNumber(5) @JvmField val msgNearbyEventList: List<AppointDefine.NearbyEvent> = emptyList(),
+        @ProtoNumber(6) @JvmField val msgFeedEventList: List<AppointDefine.FeedEvent> = emptyList(),
         @ProtoNumber(7) @JvmField val maxFreshEventId: Long = 0L
     ) : ProtoBuf
 }
@@ -1326,7 +1326,7 @@ internal class Oidb0xc0b : ProtoBuf {
         @ProtoNumber(2) @JvmField val canGetCoinCount: Int = 0,
         @ProtoNumber(3) @JvmField val coinIconUrl: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(5) @JvmField val lastCompletedTaskStamp: Long = 0L,
-        @ProtoNumber(6) @JvmField val cmsWording: List<KanDianCMSActivityInfo>? = null,
+        @ProtoNumber(6) @JvmField val cmsWording: List<KanDianCMSActivityInfo> = emptyList(),
         @ProtoNumber(7) @JvmField val lastCmsActivityStamp: Long = 0L,
         @ProtoNumber(8) @JvmField val msgKandianCoinRemind: KanDianCoinRemind? = null,
         @ProtoNumber(9) @JvmField val msgKandianTaskRemind: KanDianTaskRemind? = null
@@ -1393,10 +1393,10 @@ internal class Cmd0x7ce : ProtoBuf {
         @ProtoNumber(3) @JvmField val score: Int = 0,
         @ProtoNumber(4) @JvmField val joinOver: Int = 0,
         @ProtoNumber(5) @JvmField val joinNext: Int = 0,
-        @ProtoNumber(6) @JvmField val msgStrangerInfo: List<AppointDefine.StrangerInfo>? = null,
+        @ProtoNumber(6) @JvmField val msgStrangerInfo: List<AppointDefine.StrangerInfo> = emptyList(),
         @ProtoNumber(7) @JvmField val viewOver: Int = 0,
         @ProtoNumber(8) @JvmField val viewNext: Int = 0,
-        @ProtoNumber(9) @JvmField val msgVistorInfo: List<AppointDefine.StrangerInfo>? = null,
+        @ProtoNumber(9) @JvmField val msgVistorInfo: List<AppointDefine.StrangerInfo> = emptyList(),
         @ProtoNumber(10) @JvmField val meJoin: Int = 0,
         @ProtoNumber(12) @JvmField val canProfile: Int = 0,
         @ProtoNumber(13) @JvmField val profileErrmsg: String = "",
@@ -1405,27 +1405,27 @@ internal class Cmd0x7ce : ProtoBuf {
         @ProtoNumber(16) @JvmField val sigC2C: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(17) @JvmField val uin: Long = 0L,
         @ProtoNumber(18) @JvmField val limited: Int = 0,
-        @ProtoNumber(19) @JvmField val msgCommentList: List<AppointDefine.DateComment>? = null,
+        @ProtoNumber(19) @JvmField val msgCommentList: List<AppointDefine.DateComment> = emptyList(),
         @ProtoNumber(20) @JvmField val commentOver: Int = 0,
         @ProtoNumber(23) @JvmField val meInvited: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgAppointsInfo: List<AppintDetail>? = null,
+        @ProtoNumber(1) @JvmField val msgAppointsInfo: List<AppintDetail> = emptyList(),
         @ProtoNumber(2) @JvmField val secureFlag: Int = 0,
         @ProtoNumber(3) @JvmField val secureTips: String = ""
     ) : ProtoBuf
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val appointIds: List<AppointDefine.AppointID>? = null,
+        @ProtoNumber(1) @JvmField val appointIds: List<AppointDefine.AppointID> = emptyList(),
         @ProtoNumber(2) @JvmField val joinStart: Int = 0,
         @ProtoNumber(3) @JvmField val joinWant: Int = 0,
         @ProtoNumber(4) @JvmField val viewStart: Int = 0,
         @ProtoNumber(5) @JvmField val viewWant: Int = 0,
         @ProtoNumber(6) @JvmField val msgLbsInfo: AppointDefine.LBSInfo? = null,
-        @ProtoNumber(7) @JvmField val uint64Uins: List<Long>? = null,
+        @ProtoNumber(7) @JvmField val uint64Uins: List<Long> = emptyList(),
         @ProtoNumber(8) @JvmField val viewCommentCount: Int = 0,
         @ProtoNumber(100) @JvmField val requestUin: Long = 0L
     ) : ProtoBuf
@@ -1446,7 +1446,7 @@ internal class Cmd0x7db : ProtoBuf {
         @ProtoNumber(1) @JvmField val msgAppointId: AppointDefine.AppointID? = null,
         @ProtoNumber(2) @JvmField val appointAction: Int = 0,
         @ProtoNumber(3) @JvmField val overwrite: Int = 0,
-        @ProtoNumber(4) @JvmField val msgAppointIds: List<AppointDefine.AppointID>? = null
+        @ProtoNumber(4) @JvmField val msgAppointIds: List<AppointDefine.AppointID> = emptyList()
     ) : ProtoBuf
 }
 
@@ -1455,7 +1455,7 @@ internal class Oidb0xc6c : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val uin: Long = 0L,
-        @ProtoNumber(2) @JvmField val msgGroupInfo: List<GroupInfo>? = null
+        @ProtoNumber(2) @JvmField val msgGroupInfo: List<GroupInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1486,13 +1486,13 @@ internal class Oidb0xc05 : ProtoBuf {
     @Serializable
     internal class GetCreateAppListRsp(
         @ProtoNumber(1) @JvmField val totalCount: Int = 0,
-        @ProtoNumber(2) @JvmField val appinfos: List<Qqconnect.Appinfo>? = null
+        @ProtoNumber(2) @JvmField val appinfos: List<Qqconnect.Appinfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class GetAuthAppListRsp(
         @ProtoNumber(1) @JvmField val totalCount: Int = 0,
-        @ProtoNumber(2) @JvmField val appinfos: List<Qqconnect.Appinfo>? = null,
+        @ProtoNumber(2) @JvmField val appinfos: List<Qqconnect.Appinfo> = emptyList(),
         @ProtoNumber(3) @JvmField val curIndex: Int = 0
     ) : ProtoBuf
 
@@ -1513,7 +1513,7 @@ internal class Oidb0xc05 : ProtoBuf {
 internal class Cmd0x7da : ProtoBuf {
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val msgAppointIds: List<AppointDefine.AppointID>? = null,
+        @ProtoNumber(1) @JvmField val msgAppointIds: List<AppointDefine.AppointID> = emptyList(),
         @ProtoNumber(2) @JvmField val appointOperation: Int = 0,
         @ProtoNumber(3) @JvmField val operationReason: Int = 0,
         @ProtoNumber(4) @JvmField val overwrite: Int = 0
@@ -1522,7 +1522,7 @@ internal class Cmd0x7da : ProtoBuf {
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val wording: String = "",
-        @ProtoNumber(2) @JvmField val msgAppointInfo: List<AppointDefine.AppointInfo>? = null,
+        @ProtoNumber(2) @JvmField val msgAppointInfo: List<AppointDefine.AppointInfo> = emptyList(),
         @ProtoNumber(3) @JvmField val operationReason: Int = 0
     ) : ProtoBuf
 }
@@ -1531,8 +1531,8 @@ internal class Cmd0x7da : ProtoBuf {
 internal class Qqconnect : ProtoBuf {
     @Serializable
     internal class MobileAppInfo(
-        @ProtoNumber(11) @JvmField val androidAppInfo: List<AndroidAppInfo>? = null,
-        @ProtoNumber(12) @JvmField val iosAppInfo: List<IOSAppInfo>? = null
+        @ProtoNumber(11) @JvmField val androidAppInfo: List<AndroidAppInfo> = emptyList(),
+        @ProtoNumber(12) @JvmField val iosAppInfo: List<IOSAppInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1567,7 +1567,7 @@ internal class Qqconnect : ProtoBuf {
         @ProtoNumber(28) @JvmField val universalLink: String = "",
         @ProtoNumber(29) @JvmField val qqconnectFeature: Int = 0,
         @ProtoNumber(30) @JvmField val isHatchery: Int = 0,
-        @ProtoNumber(31) @JvmField val testUinList: List<Long>? = null,
+        @ProtoNumber(31) @JvmField val testUinList: List<Long> = emptyList(),
         @ProtoNumber(100) @JvmField val templateMsgConfig: TemplateMsgConfig? = null,
         @ProtoNumber(101) @JvmField val miniAppInfo: MiniAppInfo? = null,
         @ProtoNumber(102) @JvmField val webAppInfo: WebAppInfo? = null,
@@ -1695,19 +1695,19 @@ internal class Oidb0xc26 : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgPersons: List<MayKnowPerson>? = null,
-        @ProtoNumber(2) @JvmField val entryInuse: List<Int> = listOf(),
-        @ProtoNumber(3) @JvmField val entryClose: List<Int> = listOf(),
+        @ProtoNumber(1) @JvmField val msgPersons: List<MayKnowPerson> = emptyList(),
+        @ProtoNumber(2) @JvmField val entryInuse: List<Int> = emptyList(),
+        @ProtoNumber(3) @JvmField val entryClose: List<Int> = emptyList(),
         @ProtoNumber(4) @JvmField val nextGap: Int = 0,
         @ProtoNumber(5) @JvmField val timestamp: Int = 0,
         @ProtoNumber(6) @JvmField val msgUp: Int = 0,
-        @ProtoNumber(7) @JvmField val entryDelays: List<EntryDelay>? = null,
+        @ProtoNumber(7) @JvmField val entryDelays: List<EntryDelay> = emptyList(),
         @ProtoNumber(8) @JvmField val listSwitch: Int = 0,
         @ProtoNumber(9) @JvmField val addPageListSwitch: Int = 0,
         @ProtoNumber(10) @JvmField val emRspDataType: Int /* enum */ = 1,
-        @ProtoNumber(11) @JvmField val msgRgroupItems: List<RecommendInfo>? = null,
+        @ProtoNumber(11) @JvmField val msgRgroupItems: List<RecommendInfo> = emptyList(),
         @ProtoNumber(12) @JvmField val boolIsNewuser: Boolean = false,
-        @ProtoNumber(13) @JvmField val msgTables: List<TabInfo>? = null,
+        @ProtoNumber(13) @JvmField val msgTables: List<TabInfo> = emptyList(),
         @ProtoNumber(14) @JvmField val cookies: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -1743,14 +1743,14 @@ internal class Oidb0xc26 : ProtoBuf {
         @ProtoNumber(17) @JvmField val mobileName: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(18) @JvmField val token: String = "",
         @ProtoNumber(19) @JvmField val onlineState: Int = 0,
-        @ProtoNumber(20) @JvmField val msgLabels: List<Label>? = null,
+        @ProtoNumber(20) @JvmField val msgLabels: List<Label> = emptyList(),
         @ProtoNumber(21) @JvmField val sourceid: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class RecommendInfo(
         @ProtoNumber(1) @JvmField val woring: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(2) @JvmField val msgGroups: List<RgroupInfo>? = null
+        @ProtoNumber(2) @JvmField val msgGroups: List<RgroupInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1760,7 +1760,7 @@ internal class Oidb0xc26 : ProtoBuf {
         @ProtoNumber(3) @JvmField val groupName: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(4) @JvmField val groupMemo: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(5) @JvmField val memberNum: Int = 0,
-        @ProtoNumber(6) @JvmField val groupLabel: List<RgoupLabel>? = null,
+        @ProtoNumber(6) @JvmField val groupLabel: List<RgoupLabel> = emptyList(),
         @ProtoNumber(7) @JvmField val groupFlagExt: Int = 0,
         @ProtoNumber(8) @JvmField val groupFlag: Int = 0,
         @ProtoNumber(9) @JvmField val source: Int /* enum */ = 1,
@@ -1774,9 +1774,9 @@ internal class Oidb0xc26 : ProtoBuf {
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val filterUins: List<Long>? = null,
+        @ProtoNumber(1) @JvmField val filterUins: List<Long> = emptyList(),
         @ProtoNumber(2) @JvmField val phoneBook: Int = 0,
-        @ProtoNumber(3) @JvmField val expectedUins: List<Long>? = null,
+        @ProtoNumber(3) @JvmField val expectedUins: List<Long> = emptyList(),
         @ProtoNumber(4) @JvmField val emEntry: Int /* enum */ = 1,
         @ProtoNumber(5) @JvmField val fetchRgroup: Int = 0,
         @ProtoNumber(6) @JvmField val tabId: Int = 0,
@@ -1803,7 +1803,7 @@ internal class Oidb0xc26 : ProtoBuf {
 internal class Cmd0xac6 : ProtoBuf {
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val results: List<OperateResult>? = null,
+        @ProtoNumber(1) @JvmField val results: List<OperateResult> = emptyList(),
         @ProtoNumber(4) @JvmField val metalCount: Int = 0,
         @ProtoNumber(5) @JvmField val metalTotal: Int = 0,
         @ProtoNumber(9) @JvmField val int32NewCount: Int = 0,
@@ -1813,7 +1813,7 @@ internal class Cmd0xac6 : ProtoBuf {
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val medals: List<MedalReport>? = null,
+        @ProtoNumber(1) @JvmField val medals: List<MedalReport> = emptyList(),
         @ProtoNumber(2) @JvmField val clean: Int = 0
     ) : ProtoBuf
 
@@ -1861,7 +1861,7 @@ internal class Cmd0x7cf : ProtoBuf {
         @ProtoNumber(2) @JvmField val start: Int = 0,
         @ProtoNumber(3) @JvmField val want: Int = 0,
         @ProtoNumber(4) @JvmField val reqValidOnly: Int = 0,
-        @ProtoNumber(5) @JvmField val msgAppointIds: List<AppointDefine.AppointID>? = null,
+        @ProtoNumber(5) @JvmField val msgAppointIds: List<AppointDefine.AppointID> = emptyList(),
         @ProtoNumber(6) @JvmField val appointOperation: Int = 0,
         @ProtoNumber(100) @JvmField val requestUin: Long = 0L
     ) : ProtoBuf
@@ -1871,7 +1871,7 @@ internal class Cmd0x7cf : ProtoBuf {
         @ProtoNumber(1) @JvmField val stamp: Int = 0,
         @ProtoNumber(2) @JvmField val over: Int = 0,
         @ProtoNumber(3) @JvmField val next: Int = 0,
-        @ProtoNumber(4) @JvmField val msgAppointsInfo: List<AppointDefine.AppointInfo>? = null,
+        @ProtoNumber(4) @JvmField val msgAppointsInfo: List<AppointDefine.AppointInfo> = emptyList(),
         @ProtoNumber(5) @JvmField val unreadCount: Int = 0
     ) : ProtoBuf
 }
@@ -1899,7 +1899,7 @@ internal class Cmd0xac7 : ProtoBuf {
 
     @Serializable
     internal class ReceiveMessageDevices(
-        @ProtoNumber(1) @JvmField val devices: List<DeviceInfo>? = null
+        @ProtoNumber(1) @JvmField val devices: List<DeviceInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -1914,7 +1914,7 @@ internal class Cmd0xac7 : ProtoBuf {
 internal class Cmd0x5fa : ProtoBuf {
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgStrangerInfo: List<AppointDefine.StrangerInfo>? = null,
+        @ProtoNumber(1) @JvmField val msgStrangerInfo: List<AppointDefine.StrangerInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val reachStart: Int = 0,
         @ProtoNumber(3) @JvmField val reachEnd: Int = 0
     ) : ProtoBuf
@@ -1949,7 +1949,7 @@ internal class FavoriteCKVData : ProtoBuf {
     @Serializable
     internal class KandianFavoriteItem(
         @ProtoNumber(1) @JvmField val msgFavoriteExtInfo: KandianFavoriteBizData? = null,
-        @ProtoNumber(2) @JvmField val bytesCid: List<ByteArray>? = null,
+        @ProtoNumber(2) @JvmField val bytesCid: List<ByteArray> = emptyList(),
         @ProtoNumber(3) @JvmField val type: Int = 0,
         @ProtoNumber(4) @JvmField val status: Int = 0,
         @ProtoNumber(5) @JvmField val msgAuthor: Author? = null,
@@ -1966,7 +1966,7 @@ internal class FavoriteCKVData : ProtoBuf {
         @ProtoNumber(2) @JvmField val title: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(3) @JvmField val publisher: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(4) @JvmField val brief: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(5) @JvmField val msgPicInfo: List<PicInfo>? = null,
+        @ProtoNumber(5) @JvmField val msgPicInfo: List<PicInfo> = emptyList(),
         @ProtoNumber(6) @JvmField val type: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(7) @JvmField val resourceUri: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
@@ -1975,7 +1975,7 @@ internal class FavoriteCKVData : ProtoBuf {
     internal class UserFavoriteList(
         @ProtoNumber(1) @JvmField val uin: Long = 0L,
         @ProtoNumber(2) @JvmField val modifyTs: Long = 0L,
-        @ProtoNumber(100) @JvmField val msgFavoriteItems: List<FavoriteItem>? = null
+        @ProtoNumber(100) @JvmField val msgFavoriteItems: List<FavoriteItem> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -2038,14 +2038,14 @@ internal class Oidb0xccd : ProtoBuf {
     @Serializable
     internal class ReqBody(
         @ProtoNumber(1) @JvmField val int64Uin: Long = 0L,
-        @ProtoNumber(2) @JvmField val appids: List<Int>? = null,
+        @ProtoNumber(2) @JvmField val appids: List<Int> = emptyList(),
         @ProtoNumber(3) @JvmField val platform: Int = 0
     ) : ProtoBuf
 
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val errcode: Int = 0,
-        @ProtoNumber(2) @JvmField val results: List<Result>? = null
+        @ProtoNumber(2) @JvmField val results: List<Result> = emptyList()
     ) : ProtoBuf
 }
 
@@ -2053,7 +2053,7 @@ internal class Oidb0xccd : ProtoBuf {
 internal class Oidb0xc36 : ProtoBuf {
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val uint64Uins: List<Long>? = null
+        @ProtoNumber(1) @JvmField val uint64Uins: List<Long> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -2085,7 +2085,7 @@ internal class Oidb0x87c : ProtoBuf {
 internal class Cmd0xbf2 : ProtoBuf {
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val phoneAddrBook: List<PhoneAddrBook>? = null,
+        @ProtoNumber(1) @JvmField val phoneAddrBook: List<PhoneAddrBook> = emptyList(),
         @ProtoNumber(2) @JvmField val end: Int = 0,
         @ProtoNumber(3) @JvmField val nextIndex: Long = 0
     ) : ProtoBuf
@@ -2123,7 +2123,7 @@ internal class Cmd0x6cd : ProtoBuf {
         @ProtoNumber(11) @JvmField val msgRedpointExtraInfo: RepointExtraInfo? = null,
         @ProtoNumber(12) @JvmField val configVersion: String = "",
         @ProtoNumber(13) @JvmField val doActivity: Int = 0,
-        @ProtoNumber(14) @JvmField val msgUnreadMsg: List<MessageRec>? = null
+        @ProtoNumber(14) @JvmField val msgUnreadMsg: List<MessageRec> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -2134,14 +2134,14 @@ internal class Cmd0x6cd : ProtoBuf {
 
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgRedpoint: List<RedpointInfo>? = null,
-        @ProtoNumber(2) @JvmField val unfinishedRedpoint: List<PullRedpointReq>? = null
+        @ProtoNumber(1) @JvmField val msgRedpoint: List<RedpointInfo> = emptyList(),
+        @ProtoNumber(2) @JvmField val unfinishedRedpoint: List<PullRedpointReq> = emptyList()
     ) : ProtoBuf
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val lastPullRedpoint: List<PullRedpointReq>? = null,
-        @ProtoNumber(2) @JvmField val unfinishedRedpoint: List<PullRedpointReq>? = null,
+        @ProtoNumber(1) @JvmField val lastPullRedpoint: List<PullRedpointReq> = emptyList(),
+        @ProtoNumber(2) @JvmField val unfinishedRedpoint: List<PullRedpointReq> = emptyList(),
         @ProtoNumber(3) @JvmField val msgPullSingleTask: PullRedpointReq? = null,
         @ProtoNumber(4) @JvmField val retMsgRec: Int = 0
     ) : ProtoBuf
@@ -2235,7 +2235,7 @@ internal class Cmd0x8b4 : ProtoBuf {
         @ProtoNumber(2) @JvmField val groupName: String = "",
         @ProtoNumber(3) @JvmField val faceUrl: String = "",
         @ProtoNumber(4) @JvmField val setDisplayTime: Int = 0,
-        // @SerialId(5) @JvmField val groupLabel: List<GroupLabel.Label>? = null,
+        // @SerialId(5) @JvmField val groupLabel: List<GroupLabel.Label> = emptyList(),
         @ProtoNumber(6) @JvmField val textIntro: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(7) @JvmField val richIntro: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
@@ -2254,8 +2254,8 @@ internal class Cmd0x8b4 : ProtoBuf {
         @ProtoNumber(1) @JvmField val result: Int = 0,
         @ProtoNumber(2) @JvmField val flag: Int = 0,
         @ProtoNumber(21) @JvmField val tag: ByteArray = EMPTY_BYTE_ARRAY,
-        @ProtoNumber(22) @JvmField val groupInfo: List<GroupInfo>? = null,
-        @ProtoNumber(23) @JvmField val textLabel: List<ByteArray>? = null
+        @ProtoNumber(22) @JvmField val groupInfo: List<GroupInfo> = emptyList(),
+        @ProtoNumber(23) @JvmField val textLabel: List<ByteArray> = emptyList()
     ) : ProtoBuf
 }
 
@@ -2263,7 +2263,7 @@ internal class Cmd0x8b4 : ProtoBuf {
 internal class Cmd0x682 : ProtoBuf {
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val msgChatinfo: List<ChatInfo>? = null
+        @ProtoNumber(1) @JvmField val msgChatinfo: List<ChatInfo> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -2281,7 +2281,7 @@ internal class Cmd0x682 : ProtoBuf {
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val uint64Touinlist: List<Long>? = null
+        @ProtoNumber(1) @JvmField val uint64Touinlist: List<Long> = emptyList()
     ) : ProtoBuf
 }
 
@@ -2306,7 +2306,7 @@ internal class Cmd0x6f5 : ProtoBuf {
     @Serializable
     internal class RspBody(
         @ProtoNumber(1) @JvmField val configVersion: String = "",
-        @ProtoNumber(2) @JvmField val taskInfo: List<TaskInfo>? = null
+        @ProtoNumber(2) @JvmField val taskInfo: List<TaskInfo> = emptyList()
     ) : ProtoBuf
 }
 
@@ -2314,7 +2314,7 @@ internal class Cmd0x6f5 : ProtoBuf {
 internal class Oidb0xb7e : ProtoBuf {
     @Serializable
     internal class RspBody(
-        @ProtoNumber(1) @JvmField val topItem: List<DiandianTopConfig>? = null
+        @ProtoNumber(1) @JvmField val topItem: List<DiandianTopConfig> = emptyList()
     ) : ProtoBuf
 
     @Serializable
@@ -2357,7 +2357,7 @@ internal class Oidb0xc2f : ProtoBuf {
 
     @Serializable
     internal class GetFollowUserRecommendListRsp(
-        @ProtoNumber(1) @JvmField val msgRecommendList: List<RecommendAccountInfo>? = null,
+        @ProtoNumber(1) @JvmField val msgRecommendList: List<RecommendAccountInfo> = emptyList(),
         @ProtoNumber(2) @JvmField val jumpUrl: ByteArray = EMPTY_BYTE_ARRAY
     ) : ProtoBuf
 
@@ -2418,7 +2418,7 @@ internal class Cmd0x6ce : ProtoBuf {
 
     @Serializable
     internal class ReqBody(
-        @ProtoNumber(1) @JvmField val msgReadReq: List<ReadRedpointReq>? = null
+        @ProtoNumber(1) @JvmField val msgReadReq: List<ReadRedpointReq> = emptyList()
     ) : ProtoBuf
 }
 

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/PbReserve.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/PbReserve.kt
@@ -49,7 +49,7 @@ internal class ResvAttr(
         @ProtoNumber(40) @JvmField val groupConfessSig: ByteArray = EMPTY_BYTE_ARRAY,
         @ProtoNumber(41) @JvmField val subfontId: Long = 0L,
         @ProtoNumber(42) @JvmField val msgFlagType: Int = 0,
-        @ProtoNumber(43) @JvmField val uint32CustomFeatureid: List<Int>? = null,
+        @ProtoNumber(43) @JvmField val uint32CustomFeatureid: List<Int> = emptyList(),
         @ProtoNumber(44) @JvmField val richCardNameVer: Int = 0,
         @ProtoNumber(47) @JvmField val msgInfoFlag: Int = 0,
         @ProtoNumber(48) @JvmField val serviceMsgType: Int = 0,

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/StatSvcGetOnline.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/StatSvcGetOnline.kt
@@ -25,6 +25,6 @@ internal class StatSvcGetOnline {
         @ProtoNumber(3) @JvmField val uin: Long = 0L,
         @ProtoNumber(4) @JvmField val appid: Int = 0,
         @ProtoNumber(5) @JvmField val timeInterval: Int = 0,
-        @ProtoNumber(6) @JvmField val msgInstances: List<StatSvcGetOnline.Instance>? = null
+        @ProtoNumber(6) @JvmField val msgInstances: List<StatSvcGetOnline.Instance> = emptyList()
     ) : ProtoBuf
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/StructMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/StructMsg.kt
@@ -147,7 +147,7 @@ internal class Structmsg : ProtoBuf {
     @Serializable
     internal class RspNextSystemMsg(
         @ProtoNumber(1) @JvmField val head: RspHead? = null,
-        @ProtoNumber(2) @JvmField val msgs: List<StructMsg>? = null,
+        @ProtoNumber(2) @JvmField val msgs: List<StructMsg> = emptyList(),
         @ProtoNumber(3) @JvmField val followingFriendSeq: Long = 0L,
         @ProtoNumber(4) @JvmField val followingGroupSeq: Long = 0L,
         @ProtoNumber(5) @JvmField val checktype: Int /* enum */ = 1,
@@ -159,7 +159,7 @@ internal class Structmsg : ProtoBuf {
     @Serializable
     internal class RspSystemMsg(
         @ProtoNumber(1) @JvmField val head: RspHead? = null,
-        @ProtoNumber(2) @JvmField val msgs: List<StructMsg>? = null,
+        @ProtoNumber(2) @JvmField val msgs: List<StructMsg> = emptyList(),
         @ProtoNumber(3) @JvmField val unreadCount: Int = 0,
         @ProtoNumber(4) @JvmField val latestFriendSeq: Long = 0L,
         @ProtoNumber(5) @JvmField val latestGroupSeq: Long = 0L,
@@ -186,8 +186,8 @@ internal class Structmsg : ProtoBuf {
         @ProtoNumber(5) @JvmField val latestGroupSeq: Long = 0L,
         @ProtoNumber(6) @JvmField val followingFriendSeq: Long = 0L,
         @ProtoNumber(7) @JvmField val followingGroupSeq: Long = 0L,
-        @ProtoNumber(9) @JvmField val friendmsgs: List<StructMsg>? = null,
-        @ProtoNumber(10) @JvmField val groupmsgs: List<StructMsg>? = null,
+        @ProtoNumber(9) @JvmField val friendmsgs: List<StructMsg> = emptyList(),
+        @ProtoNumber(10) @JvmField val groupmsgs: List<StructMsg> = emptyList(),
         @ProtoNumber(11) @JvmField val msgRibbonFriend: StructMsg? = null,
         @ProtoNumber(12) @JvmField val msgRibbonGroup: StructMsg? = null,
         @ProtoNumber(13) @JvmField val msgDisplay: String = "",
@@ -227,7 +227,7 @@ internal class Structmsg : ProtoBuf {
         @ProtoNumber(6) @JvmField val msgDecided: String = "",
         @ProtoNumber(7) @JvmField val srcId: Int = 0,
         @ProtoNumber(8) @JvmField val subSrcId: Int = 0,
-        @ProtoNumber(9) @JvmField val actions: List<SystemMsgAction>? = null,
+        @ProtoNumber(9) @JvmField val actions: List<SystemMsgAction> = emptyList(),
         @ProtoNumber(10) @JvmField val groupCode: Long = 0L,
         @ProtoNumber(11) @JvmField val actionUin: Long = 0L,
         @ProtoNumber(12) @JvmField val groupMsgType: Int = 0,

--- a/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/msgType0x210.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/data/proto/msgType0x210.kt
@@ -150,8 +150,8 @@ internal class Submsgtype0x111 {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val type: Long = 0L,
-            @ProtoNumber(2) @JvmField val msgAddRecommendPersons: List<MayKnowPerson>? = null,
-            @ProtoNumber(3) @JvmField val uint64DelUins: List<Long>? = null
+            @ProtoNumber(2) @JvmField val msgAddRecommendPersons: List<MayKnowPerson> = emptyList(),
+            @ProtoNumber(3) @JvmField val uint64DelUins: List<Long> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -204,8 +204,8 @@ internal class Submsgtype0x116 {
 
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgMemberJoin: List<MemberInfo>? = null,
-            @ProtoNumber(2) @JvmField val msgMemberQuit: List<MemberInfo>? = null,
+            @ProtoNumber(1) @JvmField val msgMemberJoin: List<MemberInfo> = emptyList(),
+            @ProtoNumber(2) @JvmField val msgMemberQuit: List<MemberInfo> = emptyList(),
             @ProtoNumber(3) @JvmField val groupId: Int = 0,
             @ProtoNumber(4) @JvmField val roomId: Int = 0,
             @ProtoNumber(5) @JvmField val inviteListTotalCount: Int = 0,
@@ -220,7 +220,7 @@ internal class Submsgtype0x117 {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
-            @ProtoNumber(2) @JvmField val uint32MoudleId: List<Int>? = null
+            @ProtoNumber(2) @JvmField val uint32MoudleId: List<Int> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -283,7 +283,7 @@ internal class Submsgtype0x11a {
         @Serializable
         internal class UserData(
             @ProtoNumber(1) @JvmField val ip: ByteArray = EMPTY_BYTE_ARRAY,
-            @ProtoNumber(2) @JvmField val fixed32Port: List<Int>? = null,
+            @ProtoNumber(2) @JvmField val fixed32Port: List<Int> = emptyList(),
             @ProtoNumber(3) @JvmField val ssid: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(4) @JvmField val bssid: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(5) @JvmField val enumPlatform: Int /* enum */ = 1
@@ -339,10 +339,10 @@ internal class Submsgtype0x11f {
             @ProtoNumber(3) @JvmField val versionCtrl: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(4) @JvmField val aioType: Int = 0,
             @ProtoNumber(5) @JvmField val operUin: Long = 0L,
-            @ProtoNumber(6) @JvmField val uint64ToUin: List<Long>? = null,
+            @ProtoNumber(6) @JvmField val uint64ToUin: List<Long> = emptyList(),
             @ProtoNumber(7) @JvmField val grayTips: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(8) @JvmField val msgSeq: Long = 0L,
-            @ProtoNumber(9) @JvmField val msgMediaUin: List<MediaUserInfo>? = null,
+            @ProtoNumber(9) @JvmField val msgMediaUin: List<MediaUserInfo> = emptyList(),
             @ProtoNumber(10) @JvmField val msgPerSetting: PersonalSetting? = null,
             @ProtoNumber(11) @JvmField val playMode: Int = 0,
             @ProtoNumber(99) @JvmField val mediaType: Int = 0,
@@ -392,7 +392,7 @@ internal class Submsgtype0x122 {
             @ProtoNumber(4) @JvmField val c2cType: Int = 0,
             @ProtoNumber(5) @JvmField val serviceType: Int = 0,
             @ProtoNumber(6) @JvmField val templId: Long = 0L,
-            @ProtoNumber(7) @JvmField val msgTemplParam: List<TemplParam>? = null,
+            @ProtoNumber(7) @JvmField val msgTemplParam: List<TemplParam> = emptyList(),
             @ProtoNumber(8) @JvmField val content: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(10) @JvmField val tipsSeqId: Long = 0L,
             @ProtoNumber(100) @JvmField val pbReserv: ByteArray = EMPTY_BYTE_ARRAY
@@ -417,7 +417,7 @@ internal class Submsgtype0x123 {
             @ProtoNumber(4) @JvmField val c2cType: Int = 0,
             @ProtoNumber(5) @JvmField val serviceType: Int = 0,
             @ProtoNumber(6) @JvmField val templId: Long = 0L,
-            @ProtoNumber(7) @JvmField val templParam: List<TemplParam>? = null,
+            @ProtoNumber(7) @JvmField val templParam: List<TemplParam> = emptyList(),
             @ProtoNumber(8) @JvmField val templContent: ByteArray = EMPTY_BYTE_ARRAY
         ) : ProtoBuf
 
@@ -536,7 +536,7 @@ internal class Submsgtype0x26 {
         @Serializable
         internal class AppNotifyContent(
             @ProtoNumber(1) @JvmField val text: ByteArray = EMPTY_BYTE_ARRAY,
-            @ProtoNumber(2) @JvmField val optMsgAppNotifyUser: List<AppNotifyUser>? = null
+            @ProtoNumber(2) @JvmField val optMsgAppNotifyUser: List<AppNotifyUser> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -568,7 +568,7 @@ internal class Submsgtype0x26 {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val subCmd: Int = 0,
-            @ProtoNumber(2) @JvmField val msgSubcmd0x1PushBody: List<SubCmd0x1UpdateAppUnreadNum>? = null,
+            @ProtoNumber(2) @JvmField val msgSubcmd0x1PushBody: List<SubCmd0x1UpdateAppUnreadNum> = emptyList(),
             @ProtoNumber(3) @JvmField val msgSubcmd0x2PushBody: SubCmd0x2UpdateAppList? = null,
             @ProtoNumber(4) @JvmField val msgSubcmd0x3PushBody: SubCmd0x3UpdateDiscussAppInfo? = null,
             @ProtoNumber(5) @JvmField val msgSubcmd0x4PushBody: SubCmd0x4UpdateApp? = null
@@ -584,8 +584,8 @@ internal class Submsgtype0x26 {
 
             @Serializable
             internal class SubCmd0x2UpdateAppList(
-                @ProtoNumber(1) @JvmField val msgAppId: List<AppID>? = null,
-                @ProtoNumber(2) @JvmField val uint32TimeStamp: List<Int>? = null,
+                @ProtoNumber(1) @JvmField val msgAppId: List<AppID> = emptyList(),
+                @ProtoNumber(2) @JvmField val uint32TimeStamp: List<Int> = emptyList(),
                 @ProtoNumber(3) @JvmField val groupCode: Long = 0L
             ) : ProtoBuf
 
@@ -673,7 +673,7 @@ internal class Submsgtype0x27 {
 
         @Serializable
         internal class DelFriend(
-            @ProtoNumber(1) @JvmField val uint64Uins: List<Long>? = null
+            @ProtoNumber(1) @JvmField val uint64Uins: List<Long> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -737,8 +737,8 @@ internal class Submsgtype0x27 {
         @Serializable
         internal class FriendGroup(
             @ProtoNumber(1) @JvmField val fuin: Long = 0L,
-            @ProtoNumber(2) @JvmField val uint32OldGroupId: List<Int>? = null,
-            @ProtoNumber(3) @JvmField val uint32NewGroupId: List<Int>? = null
+            @ProtoNumber(2) @JvmField val uint32OldGroupId: List<Int> = emptyList(),
+            @ProtoNumber(3) @JvmField val uint32NewGroupId: List<Int> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -807,7 +807,7 @@ internal class Submsgtype0x27 {
         internal class ModConfProfile(
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
             @ProtoNumber(2) @JvmField val confUin: Int = 0,
-            @ProtoNumber(3) @JvmField val msgProfileInfos: List<ProfileInfo>? = null
+            @ProtoNumber(3) @JvmField val msgProfileInfos: List<ProfileInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -820,24 +820,24 @@ internal class Submsgtype0x27 {
 
         @Serializable
         internal class ModFrdRoamPriv(
-            @ProtoNumber(1) @JvmField val msgRoamPriv: List<OneRoamPriv>? = null
+            @ProtoNumber(1) @JvmField val msgRoamPriv: List<OneRoamPriv> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class ModFriendGroup(
-            @ProtoNumber(1) @JvmField val msgFrdGroup: List<FriendGroup>? = null
+            @ProtoNumber(1) @JvmField val msgFrdGroup: List<FriendGroup> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class ModFriendRemark(
-            @ProtoNumber(1) @JvmField val msgFrdRmk: List<FriendRemark>? = null
+            @ProtoNumber(1) @JvmField val msgFrdRmk: List<FriendRemark> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class ModGroupMemberProfile(
             @ProtoNumber(1) @JvmField val groupUin: Long = 0L,
             @ProtoNumber(2) @JvmField val uin: Long = 0L,
-            @ProtoNumber(3) @JvmField val msgGroupMemberProfileInfos: List<GroupMemberProfileInfo>? = null,
+            @ProtoNumber(3) @JvmField val msgGroupMemberProfileInfos: List<GroupMemberProfileInfo> = emptyList(),
             @ProtoNumber(4) @JvmField val groupCode: Long = 0L
         ) : ProtoBuf
 
@@ -850,14 +850,14 @@ internal class Submsgtype0x27 {
         @Serializable
         internal class ModGroupProfile(
             @ProtoNumber(1) @JvmField val groupUin: Long = 0L,
-            @ProtoNumber(2) @JvmField val msgGroupProfileInfos: List<GroupProfileInfo>? = null,
+            @ProtoNumber(2) @JvmField val msgGroupProfileInfos: List<GroupProfileInfo> = emptyList(),
             @ProtoNumber(3) @JvmField val groupCode: Long = 0L,
             @ProtoNumber(4) @JvmField val cmdUin: Long = 0L
         ) : ProtoBuf
 
         @Serializable
         internal class ModGroupSort(
-            @ProtoNumber(1) @JvmField val msgGroupsort: List<GroupSort>? = null
+            @ProtoNumber(1) @JvmField val msgGroupsort: List<GroupSort> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -869,12 +869,12 @@ internal class Submsgtype0x27 {
         @Serializable
         internal class ModProfile(
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
-            @ProtoNumber(2) @JvmField val msgProfileInfos: List<ProfileInfo>? = null
+            @ProtoNumber(2) @JvmField val msgProfileInfos: List<ProfileInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class ModSnsGeneralInfo(
-            @ProtoNumber(1) @JvmField val msgSnsGeneralInfos: List<SnsUpateBuffer>? = null
+            @ProtoNumber(1) @JvmField val msgSnsGeneralInfos: List<SnsUpateBuffer> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -888,7 +888,7 @@ internal class Submsgtype0x27 {
 
         @Serializable
         internal class SubMsgType0x27MsgBody(
-            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody> = listOf()
+            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -976,13 +976,13 @@ internal class Submsgtype0x27 {
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
             @ProtoNumber(2) @JvmField val code: Long = 0L,
             @ProtoNumber(3) @JvmField val result: Int = 0,
-            @ProtoNumber(400) @JvmField val msgSnsUpdateItem: List<SnsUpdateItem>? = null,
-            @ProtoNumber(401) @JvmField val uint32Idlist: List<Int>? = null
+            @ProtoNumber(400) @JvmField val msgSnsUpdateItem: List<SnsUpdateItem> = emptyList(),
+            @ProtoNumber(401) @JvmField val uint32Idlist: List<Int> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class SnsUpdateFlag(
-            @ProtoNumber(1) @JvmField val msgUpdateSnsFlag: List<SnsUpdateOneFlag>? = null
+            @ProtoNumber(1) @JvmField val msgUpdateSnsFlag: List<SnsUpdateOneFlag> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1020,12 +1020,12 @@ internal class Submsgtype0x28 {
 
         @Serializable
         internal class RspFollowList(
-            @ProtoNumber(1) @JvmField val msgFollowlist: List<FollowList>? = null
+            @ProtoNumber(1) @JvmField val msgFollowlist: List<FollowList> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class RspTypeList(
-            @ProtoNumber(1) @JvmField val msgTypelist: List<TypeList>? = null
+            @ProtoNumber(1) @JvmField val msgTypelist: List<TypeList> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1042,8 +1042,8 @@ internal class Submsgtype0x30 {
     internal class SubMsgType0x30 : ProtoBuf {
         @Serializable
         internal class BlockListNotify(
-            @ProtoNumber(1) @JvmField val msgBlockUinInfo: List<BlockUinInfo>? = null,
-            @ProtoNumber(2) @JvmField val uint64DelUin: List<Long>? = null
+            @ProtoNumber(1) @JvmField val msgBlockUinInfo: List<BlockUinInfo> = emptyList(),
+            @ProtoNumber(2) @JvmField val uint64DelUin: List<Long> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1145,7 +1145,7 @@ internal class Submsgtype0x3f {
     internal class SubMsgType0x3f : ProtoBuf {
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgPubunikey: List<PubUniKey>? = null
+            @ProtoNumber(1) @JvmField val msgPubunikey: List<PubUniKey> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1179,7 +1179,7 @@ internal class Submsgtype0x41 {
             @ProtoNumber(1) @JvmField val gameName: String = "",
             @ProtoNumber(2) @JvmField val gamePic: String = "",
             @ProtoNumber(3) @JvmField val moreInfo: String = "",
-            @ProtoNumber(4) @JvmField val msgGameRsts: List<UinResult>? = null,
+            @ProtoNumber(4) @JvmField val msgGameRsts: List<UinResult> = emptyList(),
             @ProtoNumber(5) @JvmField val gameSubheading: String = "",
             @ProtoNumber(6) @JvmField val uin: Long = 0L,
             @ProtoNumber(7) @JvmField val nickname: ByteArray = EMPTY_BYTE_ARRAY
@@ -1226,7 +1226,7 @@ internal class Submsgtype0x44 {
             @ProtoNumber(5) @JvmField val processflag: Int = 0,
             @ProtoNumber(6) @JvmField val sourceid: Int = 0,
             @ProtoNumber(7) @JvmField val sourcesubid: Int = 0,
-            @ProtoNumber(8) @JvmField val strWording: List<String> = listOf()
+            @ProtoNumber(8) @JvmField val strWording: List<String> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1282,7 +1282,7 @@ internal class Submsgtype0x48 {
         @ProtoNumber(3) @JvmField val title: String = "",
         @ProtoNumber(4) @JvmField val secondTitle: String = "",
         @ProtoNumber(5) @JvmField val thirdTitle: String = "",
-        @ProtoNumber(6) @JvmField val wordingList: List<String> = listOf()
+        @ProtoNumber(6) @JvmField val wordingList: List<String> = emptyList()
     ) : ProtoBuf
 }
 
@@ -1308,7 +1308,7 @@ internal class Submsgtype0x4b {
         @ProtoNumber(7) @JvmField val pushMsgHelper: String = "",
         @ProtoNumber(8) @JvmField val pushMsgAlbum: String = "",
         @ProtoNumber(9) @JvmField val usrTotal: Int = 0,
-        @ProtoNumber(10) @JvmField val uint64User: List<Long>? = null
+        @ProtoNumber(10) @JvmField val uint64User: List<Long> = emptyList()
     ) : ProtoBuf
 
     internal class Submsgtype0x4b : ProtoBuf {
@@ -1323,7 +1323,7 @@ internal class Submsgtype0x4b {
             @ProtoNumber(7) @JvmField val pushMsgHelper: String = "",
             @ProtoNumber(8) @JvmField val pushMsgAlbum: String = "",
             @ProtoNumber(9) @JvmField val usrTotal: Int = 0,
-            @ProtoNumber(10) @JvmField val uint64User: List<Long>? = null
+            @ProtoNumber(10) @JvmField val uint64User: List<Long> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -1333,7 +1333,7 @@ internal class Submsgtype0x4e {
     internal class Submsgtype0x4e : ProtoBuf {
         @Serializable
         internal class GroupBulletin(
-            @ProtoNumber(1) @JvmField val msgContent: List<Content>? = null
+            @ProtoNumber(1) @JvmField val msgContent: List<Content> = emptyList()
         ) : ProtoBuf {
             @Serializable
             internal class Content(
@@ -1360,7 +1360,7 @@ internal class Submsgtype0x54 {
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val peerType: Int /* enum */ = 1,
             @ProtoNumber(2) @JvmField val peerUin: Long = 0L,
-            @ProtoNumber(3) @JvmField val taskList: List<TaskInfo>? = null
+            @ProtoNumber(3) @JvmField val taskList: List<TaskInfo> = emptyList()
         ) : ProtoBuf {
             @Serializable
             internal class TaskInfo(
@@ -1442,7 +1442,7 @@ internal class Submsgtype0x67 {
 
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgGrpinfo: List<GroupInfo>? = null
+            @ProtoNumber(1) @JvmField val msgGrpinfo: List<GroupInfo> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -1510,7 +1510,7 @@ internal class Submsgtype0x6f {
             @ProtoNumber(4) @JvmField val age: Int = 0,
             @ProtoNumber(5) @JvmField val coverstory: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(6) @JvmField val storysTotalNum: Long = 0L,
-            @ProtoNumber(7) @JvmField val msgVideoInfo: List<VideoInfo>? = null,
+            @ProtoNumber(7) @JvmField val msgVideoInfo: List<VideoInfo> = emptyList(),
             @ProtoNumber(8) @JvmField val wording: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(9) @JvmField val qqUin: Long = 0L
         ) : ProtoBuf
@@ -1580,7 +1580,7 @@ internal class Submsgtype0x6f {
 
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody>? = null
+            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1593,11 +1593,11 @@ internal class Submsgtype0x6f {
         @Serializable
         internal class QimFriendNotify(
             @ProtoNumber(1) @JvmField val opType: Int = 0,
-            @ProtoNumber(2) @JvmField val uint64Uins: List<Long>? = null,
+            @ProtoNumber(2) @JvmField val uint64Uins: List<Long> = emptyList(),
             @ProtoNumber(3) @JvmField val fansUnreadCount: Long = 0L,
             @ProtoNumber(4) @JvmField val fansTotalCount: Long = 0L,
             @ProtoNumber(5) @JvmField val pushTime: Long = 0L,
-            @ProtoNumber(6) @JvmField val bytesMobiles: List<ByteArray>? = null
+            @ProtoNumber(6) @JvmField val bytesMobiles: List<ByteArray> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1625,7 +1625,7 @@ internal class Submsgtype0x6f {
 
         @Serializable
         internal class QimRecomendMsg(
-            @ProtoNumber(1) @JvmField val msgRecomendList: List<QimRecomendInfo>? = null,
+            @ProtoNumber(1) @JvmField val msgRecomendList: List<QimRecomendInfo> = emptyList(),
             @ProtoNumber(2) @JvmField val timestamp: Long = 0L
         ) : ProtoBuf
 
@@ -1676,13 +1676,13 @@ internal class Submsgtype0x71 {
     internal class Submsgtype0x71 : ProtoBuf {
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgAppInfo: List<ReportAppInfo>? = null,
+            @ProtoNumber(1) @JvmField val msgAppInfo: List<ReportAppInfo> = emptyList(),
             @ProtoNumber(2) @JvmField val uiUin: Long = 0L
         ) : ProtoBuf
 
         @Serializable
         internal class RedDisplayInfo(
-            @ProtoNumber(1) @JvmField val msgRedTypeInfo: List<RedTypeInfo>? = null,
+            @ProtoNumber(1) @JvmField val msgRedTypeInfo: List<RedTypeInfo> = emptyList(),
             @ProtoNumber(2) @JvmField val msgTabDisplayInfo: RedTypeInfo? = null
         ) : ProtoBuf
 
@@ -1722,7 +1722,7 @@ internal class Submsgtype0x71 {
         internal class ReportVersion(
             @ProtoNumber(1) @JvmField val int32PlantId: Int = 0,
             @ProtoNumber(2) @JvmField val boolAllver: Boolean = false,
-            @ProtoNumber(3) @JvmField val strVersion: List<String> = listOf()
+            @ProtoNumber(3) @JvmField val strVersion: List<String> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -1746,9 +1746,9 @@ internal class Submsgtype0x76 {
     internal class SubMsgType0x76 : ProtoBuf {
         @Serializable
         internal class BirthdayNotify(
-            @ProtoNumber(1) @JvmField val msgOneFriend: List<OneBirthdayFriend>? = null,
+            @ProtoNumber(1) @JvmField val msgOneFriend: List<OneBirthdayFriend> = emptyList(),
             @ProtoNumber(2) @JvmField val reserved: Int = 0,
-            @ProtoNumber(3) @JvmField val giftMsg: List<OneGiftMessage>? = null,
+            @ProtoNumber(3) @JvmField val giftMsg: List<OneGiftMessage> = emptyList(),
             @ProtoNumber(4) @JvmField val topPicUrl: String = "",
             @ProtoNumber(5) @JvmField val extend: String = ""
         ) : ProtoBuf
@@ -1756,12 +1756,12 @@ internal class Submsgtype0x76 {
         @Serializable
         internal class GeoGraphicNotify(
             @ProtoNumber(1) @JvmField val localCity: ByteArray = EMPTY_BYTE_ARRAY,
-            @ProtoNumber(2) @JvmField val msgOneFriend: List<OneGeoGraphicFriend>? = null
+            @ProtoNumber(2) @JvmField val msgOneFriend: List<OneGeoGraphicFriend> = emptyList()
         ) : ProtoBuf
 
         @Serializable
         internal class MemorialDayNotify(
-            @ProtoNumber(1) @JvmField val anniversaryInfo: List<OneMemorialDayInfo>? = null
+            @ProtoNumber(1) @JvmField val anniversaryInfo: List<OneMemorialDayInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -1849,9 +1849,9 @@ internal class Submsgtype0x7c {
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
             @ProtoNumber(2) @JvmField val int32Cmd: Int = 0,
-            @ProtoNumber(3) @JvmField val stringCmdExt: List<String> = listOf(),
+            @ProtoNumber(3) @JvmField val stringCmdExt: List<String> = emptyList(),
             @ProtoNumber(4) @JvmField val seq: Long = 0L,
-            @ProtoNumber(5) @JvmField val stringSeqExt: List<String> = listOf()
+            @ProtoNumber(5) @JvmField val stringSeqExt: List<String> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -1884,7 +1884,7 @@ internal class Submsgtype0x83 {
     internal class SubMsgType0x83 : ProtoBuf {
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgParams: List<MsgParams>? = null,
+            @ProtoNumber(1) @JvmField val msgParams: List<MsgParams> = emptyList(),
             @ProtoNumber(2) @JvmField val seq: Long = 0L,
             @ProtoNumber(3) @JvmField val groupId: Long = 0L
         ) : ProtoBuf
@@ -1952,7 +1952,7 @@ internal class Submsgtype0x87 {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val friendMsgTypeFlag: Long = 0L,
-            @ProtoNumber(2) @JvmField val msgMsgNotify: List<MsgNotify>? = null,
+            @ProtoNumber(2) @JvmField val msgMsgNotify: List<MsgNotify> = emptyList(),
             @ProtoNumber(3) @JvmField val msgMsgNotifyUnread: MsgNotifyUnread? = null
         ) : ProtoBuf
 
@@ -1980,7 +1980,7 @@ internal class Submsgtype0x89 {
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val uiUin: Long = 0L,
             @ProtoNumber(2) @JvmField val pushRedTs: Int = 0,
-            @ProtoNumber(3) @JvmField val msgNumRed: List<NumRedBusiInfo>? = null
+            @ProtoNumber(3) @JvmField val msgNumRed: List<NumRedBusiInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2011,7 +2011,7 @@ internal class Submsgtype0x8d {
             @ProtoNumber(1) @JvmField val channelId: Long = 0L,
             @ProtoNumber(2) @JvmField val channelName: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(3) @JvmField val wording: ByteArray = EMPTY_BYTE_ARRAY,
-            @ProtoNumber(4) @JvmField val topArticleIdList: List<Long>? = null
+            @ProtoNumber(4) @JvmField val topArticleIdList: List<Long> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2054,7 +2054,7 @@ internal class Submsgtype0x8d {
 
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgNotifyInfos: List<NotifyBody>? = null,
+            @ProtoNumber(1) @JvmField val msgNotifyInfos: List<NotifyBody> = emptyList(),
             @ProtoNumber(2) @JvmField val redSpotNotifyBody: RedSpotNotifyBody? = null
         ) : ProtoBuf
 
@@ -2079,7 +2079,7 @@ internal class Submsgtype0x8d {
         @Serializable
         internal class RedSpotNotifyBody(
             @ProtoNumber(1) @JvmField val time: Int = 0,
-            @ProtoNumber(2) @JvmField val newChannelList: List<Long>? = null,
+            @ProtoNumber(2) @JvmField val newChannelList: List<Long> = emptyList(),
             @ProtoNumber(3) @JvmField val guideWording: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(4) @JvmField val msgChannelNotify: ChannelNotify? = null
         ) : ProtoBuf
@@ -2114,7 +2114,7 @@ internal class Submsgtype0x90 {
         internal class DpNotifyMsgBdoy(
             @ProtoNumber(1) @JvmField val pid: Int = 0,
             @ProtoNumber(2) @JvmField val din: Long = 0L,
-            @ProtoNumber(3) @JvmField val msgNotifyInfo: List<NotifyItem>? = null,
+            @ProtoNumber(3) @JvmField val msgNotifyInfo: List<NotifyItem> = emptyList(),
             @ProtoNumber(4) @JvmField val extendInfo: String = ""
         ) : ProtoBuf
 
@@ -2207,7 +2207,7 @@ internal class Submsgtype0x93 {
             @ProtoNumber(3) @JvmField val enumMsgType: Int /* enum */ = 1,
             @ProtoNumber(4) @JvmField val extMsg: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(5) @JvmField val reqUin: Long = 0L,
-            @ProtoNumber(6) @JvmField val msgLiteMailIndex: List<LiteMailIndexInfo>? = null
+            @ProtoNumber(6) @JvmField val msgLiteMailIndex: List<LiteMailIndexInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2305,7 +2305,7 @@ internal class Submsgtype0x9b {
         @Serializable
         internal class PbOfficeNotify(
             @ProtoNumber(1) @JvmField val optUint32MyofficeFlag: Int = 0,
-            @ProtoNumber(2) @JvmField val uint64Appid: List<Long>? = null
+            @ProtoNumber(2) @JvmField val uint64Appid: List<Long> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -2323,7 +2323,7 @@ internal class Submsgtype0x9d {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val subCmd: Int = 0,
-            @ProtoNumber(2) @JvmField val lolaModuleUpdate: List<ModuleUpdateNotify>? = null
+            @ProtoNumber(2) @JvmField val lolaModuleUpdate: List<ModuleUpdateNotify> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -2375,7 +2375,7 @@ internal class Submsgtype0xa1 {
             @ProtoNumber(2) @JvmField val qid: Long = 0L,
             @ProtoType(ProtoIntegerType.FIXED) @ProtoNumber(3) @JvmField val fixed32UpdateTime: Int = 0,
             @ProtoNumber(4) @JvmField val teamCreatedDestroied: Int = 0,
-            @ProtoNumber(5) @JvmField val uint64OfficeFaceChangedUins: List<Long>? = null
+            @ProtoNumber(5) @JvmField val uint64OfficeFaceChangedUins: List<Long> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -2459,7 +2459,7 @@ internal class Submsgtype0xaa {
             @ProtoNumber(11) @JvmField val buildTeamTime: Long = 0L,
             @ProtoNumber(12) @JvmField val leaderUin: String = "",
             @ProtoNumber(13) @JvmField val uin32LeaderStatus: Int = 0,
-            @ProtoNumber(14) @JvmField val inviteSourceList: List<InviteSource>? = null
+            @ProtoNumber(14) @JvmField val inviteSourceList: List<InviteSource> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2603,7 +2603,7 @@ internal class Submsgtype0xae {
         @Serializable
         internal class PushPeopleMayKnowV2(
             @ProtoType(ProtoIntegerType.FIXED) @ProtoNumber(1) @JvmField val fixed32Timestamp: Int = 0,
-            @ProtoNumber(2) @JvmField val msgFriendList: List<PersonMayKnow>? = null,
+            @ProtoNumber(2) @JvmField val msgFriendList: List<PersonMayKnow> = emptyList(),
             @ProtoNumber(3) @JvmField val roleName: ByteArray = EMPTY_BYTE_ARRAY
         ) : ProtoBuf
     }
@@ -2715,7 +2715,7 @@ internal class Submsgtype0xbe {
             @ProtoNumber(2) @JvmField val groupCode: Long = 0L,
             @ProtoNumber(3) @JvmField val notifyType: Int = 0,
             @ProtoNumber(4) @JvmField val onlineLevel: Int = 0,
-            @ProtoNumber(5) @JvmField val msgMedalList: List<Medal>? = null
+            @ProtoNumber(5) @JvmField val msgMedalList: List<Medal> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -2793,7 +2793,7 @@ internal class Submsgtype0xc5 {
             @ProtoNumber(10) @JvmField val msgCommentArticle: CommentInfo? = null,
             @ProtoNumber(11) @JvmField val msgLikeArticle: LikeInfo? = null,
             @ProtoNumber(12) @JvmField val msgBbInfo: BBInfo? = null,
-            @ProtoNumber(13) @JvmField val redPointInfo: List<RedPointInfo>? = null
+            @ProtoNumber(13) @JvmField val redPointInfo: List<RedPointInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2918,7 +2918,7 @@ internal class Submsgtype0xc7 {
 
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody>? = null
+            @ProtoNumber(1) @JvmField val msgModInfos: List<ForwardBody> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2930,8 +2930,8 @@ internal class Submsgtype0xc7 {
             @ProtoNumber(5) @JvmField val msgRelationalChainInfoOld: RelationalChainInfo? = null,
             @ProtoNumber(6) @JvmField val msgRelationalChainInfoNew: RelationalChainInfo? = null,
             @ProtoNumber(7) @JvmField val msgToDegradeInfo: ToDegradeInfo? = null,
-            @ProtoNumber(20) @JvmField val relationalChainInfos: List<RelationalChainInfos>? = null,
-            @ProtoNumber(100) @JvmField val uint32FeatureId: List<Int>? = null
+            @ProtoNumber(20) @JvmField val relationalChainInfos: List<RelationalChainInfos> = emptyList(),
+            @ProtoNumber(100) @JvmField val uint32FeatureId: List<Int> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -2951,7 +2951,7 @@ internal class Submsgtype0xc7 {
 
         @Serializable
         internal class ToDegradeInfo(
-            @ProtoNumber(1) @JvmField val toDegradeItem: List<ToDegradeItem>? = null,
+            @ProtoNumber(1) @JvmField val toDegradeItem: List<ToDegradeItem> = emptyList(),
             @ProtoNumber(2) @JvmField val nick: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(3) @JvmField val notifyTime: Long = 0L
         ) : ProtoBuf
@@ -3011,7 +3011,7 @@ internal class Submsgtype0xc9 {
             @ProtoNumber(2) @JvmField val fromUin: Long = 0L,
             @ProtoNumber(3) @JvmField val actionUin: Long = 0L,
             @ProtoNumber(4) @JvmField val source: Int /* enum */ = 0,
-            @ProtoNumber(5) @JvmField val msgBusinessMsg: List<BusinessMsg>? = null,
+            @ProtoNumber(5) @JvmField val msgBusinessMsg: List<BusinessMsg> = emptyList(),
             @ProtoNumber(6) @JvmField val boolNewFriend: Boolean = false
         ) : ProtoBuf
     }
@@ -3023,7 +3023,7 @@ internal class Submsgtype0xca {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val uin: Long = 0L,
-            @ProtoNumber(2) @JvmField val msgList: List<MsgContent>? = null
+            @ProtoNumber(2) @JvmField val msgList: List<MsgContent> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -3183,9 +3183,9 @@ internal class Submsgtype0xdc {
     internal class Submsgtype0xdc : ProtoBuf {
         @Serializable
         internal class MsgBody(
-            @ProtoNumber(1) @JvmField val msgList: List<MsgContent>? = null,
+            @ProtoNumber(1) @JvmField val msgList: List<MsgContent> = emptyList(),
             @ProtoNumber(2) @JvmField val msgType: Int = 0,
-            @ProtoNumber(3) @JvmField val msgList0x02: List<MsgContent>? = null,
+            @ProtoNumber(3) @JvmField val msgList0x02: List<MsgContent> = emptyList(),
             @ProtoNumber(4) @JvmField val minQqVer: String = ""
         ) : ProtoBuf
 
@@ -3216,10 +3216,10 @@ internal class Submsgtype0xdd {
         @Serializable
         internal class MsgBody(
             @ProtoNumber(1) @JvmField val msgType: Int = 0,
-            @ProtoNumber(2) @JvmField val uint64InviteUin: List<Long>? = null,
+            @ProtoNumber(2) @JvmField val uint64InviteUin: List<Long> = emptyList(),
             @ProtoNumber(3) @JvmField val inviteLeader: Long = 0L,
             @ProtoNumber(4) @JvmField val msgPoiInfo: WifiPOIInfo? = null,
-            @ProtoNumber(5) @JvmField val msgPlayerState: List<PlayerState>? = null
+            @ProtoNumber(5) @JvmField val msgPlayerState: List<PlayerState> = emptyList()
         ) : ProtoBuf {
             @Serializable
             internal class PlayerState(
@@ -3263,7 +3263,7 @@ internal class Submsgtype0xdd {
                 @ProtoNumber(24) @JvmField val tvPkFlag: Int = 0,
                 @ProtoNumber(25) @JvmField val subType: Int = 0,
                 @ProtoNumber(26) @JvmField val lastMsgSeq: Long = 0L,
-                @ProtoNumber(27) @JvmField val msgSeatsInfo: List<SeatsInfo>? = null,
+                @ProtoNumber(27) @JvmField val msgSeatsInfo: List<SeatsInfo> = emptyList(),
                 @ProtoNumber(28) @JvmField val flowerNum: Long = 0L,
                 @ProtoNumber(29) @JvmField val flowerPoint: Long = 0L,
                 @ProtoNumber(31) @JvmField val favoritesTime: Long = 0L,
@@ -3307,7 +3307,7 @@ internal class Submsgtype0xdf {
         @Serializable
         internal class MsgBody(
             // @ProtoNumber(1) @JvmField val msgGameState: ApolloGameStatus.STCMGameMessage? = null,
-            @ProtoNumber(2) @JvmField val uint32UinList: List<Int>? = null
+            @ProtoNumber(2) @JvmField val uint32UinList: List<Int> = emptyList()
         ) : ProtoBuf
     }
 }
@@ -3557,7 +3557,7 @@ internal class Submsgtype0xee {
         internal class ContextInfo(
             @ProtoNumber(1) @JvmField val id: Long = 0L,
             @ProtoNumber(2) @JvmField val title: ByteArray = EMPTY_BYTE_ARRAY,
-            @ProtoNumber(3) @JvmField val msgPicList: List<PictureInfo>? = null,
+            @ProtoNumber(3) @JvmField val msgPicList: List<PictureInfo> = emptyList(),
             @ProtoNumber(4) @JvmField val jumpUrl: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(5) @JvmField val orangeWord: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(6) @JvmField val brief: ByteArray = EMPTY_BYTE_ARRAY,
@@ -3583,7 +3583,7 @@ internal class Submsgtype0xee {
             @ProtoNumber(1) @JvmField val id: ByteArray = EMPTY_BYTE_ARRAY,
             @ProtoNumber(2) @JvmField val seq: Long = 0L,
             @ProtoNumber(3) @JvmField val bid: Int = 0,
-            @ProtoNumber(11) @JvmField val msgNotifyList: List<NotifyInfo>? = null
+            @ProtoNumber(11) @JvmField val msgNotifyList: List<NotifyInfo> = emptyList()
         ) : ProtoBuf
 
         @Serializable
@@ -3662,7 +3662,7 @@ internal class Submsgtype0xf9 {
             @ProtoNumber(8) @JvmField val templateID: Int = 0,
             @ProtoNumber(9) @JvmField val url: String = "",
             @ProtoNumber(10) @JvmField val msgMsgCommonData: MsgCommonData? = null,
-            @ProtoNumber(11) @JvmField val msgVideo: List<Video>? = null,
+            @ProtoNumber(11) @JvmField val msgVideo: List<Video> = emptyList(),
             @ProtoNumber(12) @JvmField val pushTime: Int = 0,
             @ProtoNumber(13) @JvmField val invalidTime: Int = 0,
             @ProtoNumber(14) @JvmField val maxExposureTime: Int = 0

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/MultiMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/MultiMsg.kt
@@ -139,7 +139,7 @@ internal class MultiMsg {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val body = readProtoBuf(MultiMsg.RspBody.serializer())
-            val response = body.multimsgApplyupRsp!!.first()
+            val response = body.multimsgApplyupRsp.first()
             return when (response.result) {
                 0 -> Response.RequireUpload(response)
                 193 -> Response.MessageTooLarge

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/NewContact.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/NewContact.kt
@@ -58,7 +58,7 @@ internal class NewContact {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): NewFriendRequestEvent? {
             readBytes().loadAs(Structmsg.RspSystemMsgNew.serializer()).run {
-                val struct = friendmsgs?.firstOrNull()// 会有重复且无法过滤, 不要用 map
+                val struct = friendmsgs.firstOrNull()// 会有重复且无法过滤, 不要用 map
                 return struct?.msg?.run {
                     NewFriendRequestEvent(
                         bot,
@@ -145,7 +145,7 @@ internal class NewContact {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Packet? {
             readBytes().loadAs(Structmsg.RspSystemMsgNew.serializer()).run {
-                val struct = groupmsgs?.firstOrNull() ?: return null // 会有重复且无法过滤, 不要用 map
+                val struct = groupmsgs.firstOrNull() ?: return null // 会有重复且无法过滤, 不要用 map
 
                 if (!bot.client.syncingController.systemMsgNewGroupCacheList.addCache(
                         QQAndroidClient.MessageSvcSyncData.SystemMsgNewGroupSyncId(struct.msgSeq, struct.msgTime)

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/PbMessageSvc.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/PbMessageSvc.kt
@@ -147,13 +147,13 @@ internal class PbMessageSvc {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val resp = readProtoBuf(MsgSvc.PbMsgWithDrawResp.serializer())
-            resp.groupWithDraw?.firstOrNull()?.let {
+            resp.groupWithDraw.firstOrNull()?.let {
                 if (it.result != 0) {
                     return Response.Failed(it.result, it.errmsg)
                 }
                 return Response.Success
             }
-            resp.c2cWithDraw?.firstOrNull()?.let {
+            resp.c2cWithDraw.firstOrNull()?.let {
                 if (it.result != 2 && it.result != 3) {
                     return Response.Failed(it.result, it.errmsg)
                 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/TroopManagement.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/TroopManagement.kt
@@ -150,7 +150,7 @@ internal class TroopManagement {
     internal object Kick : OutgoingPacketFactory<Kick.Response>("OidbSvc.0x8a0_0") {
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val ret = this.readBytes()
-                .loadAs(OidbSso.OIDBSSOPkg.serializer()).bodybuffer.loadAs(Oidb0x8a0.RspBody.serializer()).msgKickResult!![0].optUint32Result
+                .loadAs(OidbSso.OIDBSSOPkg.serializer()).bodybuffer.loadAs(Oidb0x8a0.RspBody.serializer()).msgKickResult.first().optUint32Result
             return Response(
                 ret == 0,
                 ret

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/image/ImgStore.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/image/ImgStore.kt
@@ -108,15 +108,14 @@ internal class ImgStore {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val resp0 = readProtoBuf(Cmd0x388.RspBody.serializer())
-            resp0.msgTryupImgRsp ?: error("cannot find `msgTryupImgRsp` from `Cmd0x388.RspBody`")
-            val resp = resp0.msgTryupImgRsp.first()
+            val resp = resp0.msgTryupImgRsp.firstOrNull() ?: error("cannot find `msgTryupImgRsp` from `Cmd0x388.RspBody`")
             return when {
                 resp.result != 0 -> Response.Failed(resultCode = resp.result, message = resp.failMsg)
                 resp.boolFileExit -> Response.FileExists(fileId = resp.fileid, fileInfo = resp.msgImgInfo!!)
                 else -> Response.RequireUpload(fileId = resp.fileid,
                     uKey = resp.upUkey,
-                    uploadIpList = resp.uint32UpIp!!,
-                    uploadPortList = resp.uint32UpPort!!)
+                    uploadIpList = resp.uint32UpIp,
+                    uploadPortList = resp.uint32UpPort)
             }
         }
     }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/image/LongConn.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/image/LongConn.kt
@@ -43,7 +43,7 @@ internal class LongConn {
                 return Response.Failed(resp.failMsg)
             }
             check(resp.subcmd == 1)
-            val imgRsp = resp.msgTryupImgRsp!!.first()
+            val imgRsp = resp.msgTryupImgRsp.first()
             if (imgRsp.result != 0) {
                 return Response.Failed(imgRsp.failMsg ?: "")
             }
@@ -51,7 +51,7 @@ internal class LongConn {
             return if (imgRsp.boolFileExit) {
                 Response.FileExists(imgRsp.upResid, imgRsp.msgImgInfo!!)
             } else {
-                Response.RequireUpload(imgRsp.upResid, imgRsp.uint32UpIp!!, imgRsp.uint32UpPort!!, imgRsp.upUkey)
+                Response.RequireUpload(imgRsp.upResid, imgRsp.uint32UpIp, imgRsp.uint32UpPort, imgRsp.upUkey)
             }
         }
 

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/MessageSvc.PbGetMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/MessageSvc.PbGetMsg.kt
@@ -180,14 +180,14 @@ internal object MessageSvcPbGetMsg : OutgoingPacketFactory<MessageSvcPbGetMsg.Re
 
         bot.client.syncingController.msgCtrlBuf = resp.msgCtrlBuf
 
-        if (resp.uinPairMsgs == null) {
+        if (resp.uinPairMsgs.isEmpty()) {
             return EmptyResponse
         }
 
         val messages = resp.uinPairMsgs.asFlow()
-            .filterNot { it.msg == null }
+            .filterNot { it.msg.isEmpty() }
             .flatMapConcat {
-                it.msg!!.asFlow()
+                it.msg.asFlow()
                     .filter { msg: MsgComm.Msg -> msg.msgHead.msgTime > it.lastReadTime.toLong() and 4294967295L }
             }.also {
                 MessageSvcPbDeleteMsg.delete(bot, it) // 删除消息

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.PbPushGroupMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.PbPushGroupMsg.kt
@@ -85,9 +85,13 @@ internal object OnlinePushPbPushGroupMsg : IncomingPacketFactory<Packet?>("Onlin
         } else {
             extraInfo?.groupCard?.takeIf { it.isNotEmpty() }?.run {
                 kotlin.runCatching {
-                    if (this[0] == 0x0A.toByte())
-                        loadAs(Oidb0x8fc.CommCardNameBuf.serializer()).richCardName?.joinToString("") { it.text.encodeToString() }
-                    else return@runCatching null
+                    if (this[0] == 0x0A.toByte()) {
+                        val nameBuf = loadAs(Oidb0x8fc.CommCardNameBuf.serializer())
+                        if (nameBuf.richCardName.isNotEmpty()) {
+                            return@runCatching nameBuf.richCardName.joinToString("") { it.text.encodeToString() }
+                        }
+                    }
+                    return@runCatching null
                 }.getOrNull() ?: encodeToString()
             } ?: pbPushMsg.msg.msgHead.groupInfo.groupCard.takeIf { it.isNotEmpty() }
             ?: sender.nameCardOrNick // 没有 extraInfo 就从 head 里取

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.ReqPush.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.ReqPush.kt
@@ -250,9 +250,9 @@ private object Transformers732 : Map<Int, Lambda732> by mapOf(
                 var from: Member = group.botAsMember
                 var target: Member = group.botAsMember
                 var suffix = ""
-                grayTip.msgTemplParam?.map {
+                grayTip.msgTemplParam.map {
                     Pair(it.name.decodeToString(), it.value.decodeToString())
-                }?.asSequence()?.forEach { (key, value) ->
+                }.asSequence().forEach { (key, value) ->
                     run {
                         when (key) {
                             "action_str" -> action = value
@@ -516,9 +516,9 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
                 var action = ""
                 var target: Friend = bot.selfQQ
                 var suffix = ""
-                body.msgTemplParam?.asSequence()?.map {
+                body.msgTemplParam.asSequence().map {
                     it.name.decodeToString() to it.value.decodeToString()
-                }?.forEach { (key, value) ->
+                }.forEach { (key, value) ->
                     when (key) {
                         "action_str" -> action = value
                         "uin_str1" -> from = bot.getFriend(value.toLong())
@@ -543,7 +543,7 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
             }
             else -> {
                 bot.logger.debug {
-                    "Unknown Transformers528 0x122L template\ntemplId=${body.templId}\nPermList=${body.msgTemplParam?._miraiContentToString()}"
+                    "Unknown Transformers528 0x122L template\ntemplId=${body.templId}\nPermList=${body.msgTemplParam._miraiContentToString()}"
                 }
                 return@lambda528 emptySequence()
             }
@@ -563,7 +563,7 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
     // 群相关,  ModFriendRemark, DelFriend, ModGroupProfile
     0x27L to lambda528 { bot ->
         fun ModFriendRemark.transform(bot: QQAndroidBot): Sequence<Packet> {
-            return this.msgFrdRmk?.asSequence()?.mapNotNull {
+            return this.msgFrdRmk.asSequence().mapNotNull {
                 val friend = bot.getFriendOrNull(it.fuin) ?: return@mapNotNull null
                 val old: String
                 friend.checkIsFriendImpl().friendInfo.checkIsInfoImpl()
@@ -571,20 +571,20 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
                     .cachedRemark = it.rmkName
                 // TODO: 2020/4/10 ADD REMARK QUERY
                 FriendRemarkChangeEvent(friend, old, it.rmkName)
-            } ?: emptySequence()
+            }
         }
 
         fun DelFriend.transform(bot: QQAndroidBot): Sequence<Packet> {
-            return this.uint64Uins?.asSequence()?.mapNotNull {
+            return this.uint64Uins.asSequence().mapNotNull {
                 val friend = bot.getFriendOrNull(it) ?: return@mapNotNull null
                 if (bot.friends.delegate.remove(friend)) {
                     FriendDeleteEvent(friend)
                 } else null
-            } ?: emptySequence()
+            }
         }
 
         fun ModGroupProfile.transform(bot: QQAndroidBot): Sequence<Packet> {
-            return this.msgGroupProfileInfos?.asSequence()?.mapNotNull { info ->
+            return this.msgGroupProfileInfos.asSequence().mapNotNull { info ->
                 when (info.field) {
                     1 -> {
                         // 群名
@@ -635,11 +635,11 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
 
                     else -> null
                 }
-            } ?: emptySequence()
+            }
         }
 
         fun ModGroupMemberProfile.transform(bot: QQAndroidBot): Sequence<Packet> {
-            return this.msgGroupMemberProfileInfos?.asSequence()?.mapNotNull { info ->
+            return this.msgGroupMemberProfileInfos.asSequence().mapNotNull { info ->
                 when (info.field) {
                     1 -> { // name card
                         val new = info.value
@@ -670,7 +670,7 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
                         return@mapNotNull null
                     }
                 }
-            } ?: emptySequence()
+            }
         }
 
         fun ModCustomFace.transform(bot: QQAndroidBot): Sequence<Packet> {
@@ -684,7 +684,7 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
         fun ModProfile.transform(bot: QQAndroidBot): Sequence<Packet> {
             return ArrayList<Packet>().apply {
                 var containsUnknown = false
-                msgProfileInfos?.forEach { modified ->
+                msgProfileInfos.forEach { modified ->
                     when (modified.field) {
                         20002 -> { // 昵称修改
                             val value = modified.value
@@ -724,7 +724,7 @@ internal object Transformers528 : Map<Long, Lambda528> by mapOf(
                         }
                     }
                 }
-                if (msgProfileInfos == null || msgProfileInfos.isEmpty() || containsUnknown) {
+                if (msgProfileInfos.isEmpty() || containsUnknown) {
                     bot.network.logger.debug {
                         "Transformers528 0x27L: new data: ${_miraiContentToString()}"
                     }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/voice/PttStore.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/voice/PttStore.kt
@@ -71,16 +71,15 @@ internal class PttStore {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val resp0 = readProtoBuf(Cmd0x388.RspBody.serializer())
-            resp0.msgTryupPttRsp ?: error("cannot find `msgTryupPttRsp` from `Cmd0x388.RspBody`")
-            val resp = resp0.msgTryupPttRsp.first()
+            val resp = resp0.msgTryupPttRsp.firstOrNull() ?: error("cannot find `msgTryupPttRsp` from `Cmd0x388.RspBody`")
             if (resp.failMsg != null) {
                 throw IllegalStateException(resp.failMsg.encodeToString())
             }
             return Response.RequireUpload(
                 fileId = resp.fileid,
                 uKey = resp.upUkey,
-                uploadIpList = resp.uint32UpIp!!,
-                uploadPortList = resp.uint32UpPort!!,
+                uploadIpList = resp.uint32UpIp,
+                uploadPortList = resp.uint32UpPort,
                 fileKey = resp.fileKey
             )
 
@@ -136,16 +135,15 @@ internal class PttStore {
 
         override suspend fun ByteReadPacket.decode(bot: QQAndroidBot): Response {
             val resp0 = readProtoBuf(Cmd0x388.RspBody.serializer())
-            resp0.msgGetpttUrlRsp ?: error("cannot find `msgGetpttUrlRsp` from `Cmd0x388.RspBody`")
-            val resp = resp0.msgGetpttUrlRsp.first()
+            val resp = resp0.msgGetpttUrlRsp.firstOrNull() ?: error("cannot find `msgGetpttUrlRsp` from `Cmd0x388.RspBody`")
             if (!resp.failMsg.contentEquals(EMPTY_BYTE_ARRAY)) {
                 throw IllegalStateException(resp.failMsg.encodeToString())
             }
             return Response.DownLoadInfo(
                 downDomain = resp.downDomain,
                 downPara = resp.downPara,
-                uint32DownIp = resp.uint32DownIp!!,
-                uint32DownPort = resp.uint32DownPort!!,
+                uint32DownIp = resp.uint32DownIp,
+                uint32DownPort = resp.uint32DownPort,
                 strDomain = resp.strDomain
             )
         }


### PR DESCRIPTION
在原代码中，List的默认值常被设置为null
ProtoBuf使用重复字段（Repeat Field）表示集合，empty等价于omitted（null同样被实现为omitted）
根据[官方指南](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats.md#lists-as-repeated-fields)，使用emptyList作为默认值是推荐行为
并且从代码上来看，使用empty代替null有利于简化逻辑，避免一些对null的操作
同时语义更加清晰（避免empty和null两种值代表同一结果）