### PR TITLE
docs: update sdk mirai-ts support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,23 +30,23 @@
 [theGravityLab/ProjHyperai]: https://github.com/theGravityLab/ProjHyperai
 [yyuueexxiinngg/cqhttp-mirai]: https://github.com/yyuueexxiinngg/cqhttp-mirai
 
-| 技术             | 维护者及项目地址                               |
-|:----------------|:--------------------------------------------|
-| *Http*          | [mamoe/mirai-api-http]                      |
-| `JavaScript`    | [iTXTech/mirai-js]                          |
-| `Python`        | [Graia Framework][GraiaProject/Application] |
-| `Node.js`       | [RedBeanN/node-mirai]                       |
-| `Go`            | [Logiase/gomirai]                           |
-| `Mozilla Rhino` | [StageGuard/mirai-rhinojs-sdk]              |
-| `C++`           | [cyanray/mirai-cpp]                         |
-| `C++`           | [Chlorie/miraipp]                           |
-| `C#`            | [Executor-Cheng/mirai-CSharp]               |
-| `Rust`          | [HoshinoTented/mirai-rs]                    |
-| `TypeScript`    | [YunYouJun/mirai-ts]                        |
-| `易语言`         | [only52607/e-mirai]                         |
-| `.Net/C#`       | [Hyperai][theGravityLab/ProjHyperai]        |
-| *酷 Q 插件*      | [iTXTech/mirai-native]                      |
-| *酷 Q HTTP*     | [yyuueexxiinngg/cqhttp-mirai]               |
+| 技术                                     | 维护者及项目地址                               |
+|:----------------------------------------|:--------------------------------------------|
+| *Http*                                  | [mamoe/mirai-api-http]                      |
+| `JavaScript`                            | [iTXTech/mirai-js]                          |
+| `Python`                                | [Graia Framework][GraiaProject/Application] |
+| `Node.js`                               | [RedBeanN/node-mirai]                       |
+| `Go`                                    | [Logiase/gomirai]                           |
+| `Mozilla Rhino`                         | [StageGuard/mirai-rhinojs-sdk]              |
+| `C++`                                   | [cyanray/mirai-cpp]                         |
+| `C++`                                   | [Chlorie/miraipp]                           |
+| `C#`                                    | [Executor-Cheng/mirai-CSharp]               |
+| `Rust`                                  | [HoshinoTented/mirai-rs]                    |
+| `JavaScript/TypeScript` (兼容浏览器端)    | [YunYouJun/mirai-ts]                        |
+| `易语言`                                 | [only52607/e-mirai]                         |
+| `.Net/C#`                               | [Hyperai][theGravityLab/ProjHyperai]        |
+| *酷 Q 插件*                              | [iTXTech/mirai-native]                      |
+| *酷 Q HTTP*                             | [yyuueexxiinngg/cqhttp-mirai]               |
 
 > *想在这里添加你的项目？欢迎[提交 PR](https://github.com/mamoe/mirai/edit/dev/docs/README.md)。*
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,23 +30,23 @@
 [theGravityLab/ProjHyperai]: https://github.com/theGravityLab/ProjHyperai
 [yyuueexxiinngg/cqhttp-mirai]: https://github.com/yyuueexxiinngg/cqhttp-mirai
 
-| 技术                                     | 维护者及项目地址                               |
-|:----------------------------------------|:--------------------------------------------|
-| *Http*                                  | [mamoe/mirai-api-http]                      |
-| `JavaScript`                            | [iTXTech/mirai-js]                          |
-| `Python`                                | [Graia Framework][GraiaProject/Application] |
-| `Node.js`                               | [RedBeanN/node-mirai]                       |
-| `Go`                                    | [Logiase/gomirai]                           |
-| `Mozilla Rhino`                         | [StageGuard/mirai-rhinojs-sdk]              |
-| `C++`                                   | [cyanray/mirai-cpp]                         |
-| `C++`                                   | [Chlorie/miraipp]                           |
-| `C#`                                    | [Executor-Cheng/mirai-CSharp]               |
-| `Rust`                                  | [HoshinoTented/mirai-rs]                    |
-| `JavaScript/TypeScript` (兼容浏览器端)    | [YunYouJun/mirai-ts]                        |
-| `易语言`                                 | [only52607/e-mirai]                         |
-| `.Net/C#`                               | [Hyperai][theGravityLab/ProjHyperai]        |
-| *酷 Q 插件*                              | [iTXTech/mirai-native]                      |
-| *酷 Q HTTP*                             | [yyuueexxiinngg/cqhttp-mirai]               |
+| 技术             | 维护者及项目地址                               |
+|:----------------|:--------------------------------------------|
+| *Http*          | [mamoe/mirai-api-http]                      |
+| `JavaScript`    | [iTXTech/mirai-js]                          |
+| `Node.js`       | [RedBeanN/node-mirai]                       |
+| `Mozilla Rhino` | [StageGuard/mirai-rhinojs-sdk]              |
+| `JavaScript`    | [YunYouJun/mirai-ts]                        |
+| `Python`        | [Graia Framework][GraiaProject/Application] |
+| `Go`            | [Logiase/gomirai]                           |
+| `C++`           | [cyanray/mirai-cpp]                         |
+| `C++`           | [Chlorie/miraipp]                           |
+| `C#`            | [Executor-Cheng/mirai-CSharp]               |
+| `Rust`          | [HoshinoTented/mirai-rs]                    |
+| `易语言`         | [only52607/e-mirai]                         |
+| `.Net/C#`       | [Hyperai][theGravityLab/ProjHyperai]        |
+| *酷 Q 插件*      | [iTXTech/mirai-native]                      |
+| *酷 Q HTTP*     | [yyuueexxiinngg/cqhttp-mirai]               |
 
 > *想在这里添加你的项目？欢迎[提交 PR](https://github.com/mamoe/mirai/edit/dev/docs/README.md)。*
 


### PR DESCRIPTION
添加 [mirai-ts](https://github.com/YunYouJun/mirai-ts) 支持技术说明。

mirai-ts 支持作为 JavaScript/TypeScript SDK 使用。

- 与 `mirai-js` 的区别：`mirai-js` 与 `mirai-console` 进行直接交互，`mirai-ts` 基于 `mirai-api-http` 交互。
- 与 `node-mirai` 的区别：`mirai-ts`使用 TypeScript 编写，编译为带有声明文件的 JavaScript 文件，可以在 IDE 中提供代码提示与补全。不局限于 `Node.js`，兼容 Browser 端（浏览器）。