### PR TITLE
Use build scan instead of --info --stacktrace

### DIFF
--- a/.github/workflows/bintray.yml
+++ b/.github/workflows/bintray.yml
@@ -32,7 +32,7 @@ jobs:
         run: chmod -R 777 *
 
       - name: Init gradle project
-        run: ./gradlew clean --info
+        run: ./gradlew clean --scan
 
       - name: Check keys
         run: >
@@ -46,31 +46,31 @@ jobs:
       - name: fillBuildConstants
         run: >
           ./gradlew
-          fillBuildConstants --info --stacktrace
+          fillBuildConstants --scan
           -Dbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_user=${{ secrets.BINTRAY_USER }}
           -Dbintray_key=${{ secrets.BINTRAY_KEY }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
 
       - name: Assemble
-        run: ./gradlew assemble --info --stacktrace
+        run: ./gradlew assemble --scan
 
       - name: Check
-        run: ./gradlew check --info --stacktrace
+        run: ./gradlew check --scan
 
       - name: Gradle :mirai-core-utils:publish
         run: >
-          ./gradlew :mirai-core-utils:publish --info --stacktrace
+          ./gradlew :mirai-core-utils:publish --scan
           -Dbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_user=${{ secrets.BINTRAY_USER }}
           -Dbintray_key=${{ secrets.BINTRAY_KEY }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
 
       - name: Gradle :mirai-core-api:publish
         run: >
-          ./gradlew :mirai-core-api:publish --info --stacktrace
+          ./gradlew :mirai-core-api:publish --scan
           -Dbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_user=${{ secrets.BINTRAY_USER }}
           -Dbintray_key=${{ secrets.BINTRAY_KEY }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
 
       - name: Gradle :mirai-core:publish
         run: >
-          ./gradlew :mirai-core:publish --info --stacktrace
+          ./gradlew :mirai-core:publish --scan
           -Dbintray_user=${{ secrets.BINTRAY_USER }} -Pbintray_user=${{ secrets.BINTRAY_USER }}
           -Dbintray_key=${{ secrets.BINTRAY_KEY }} -Pbintray_key=${{ secrets.BINTRAY_KEY }}
 
@@ -118,6 +118,6 @@ jobs:
       - name: Publish Gradle plugin
         run: >
           ./gradlew
-          :mirai-console-gradle:publishPlugins --info --stacktrace
+          :mirai-console-gradle:publishPlugins --scan
           -Dgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
           -Dgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
         run: chmod -R 777 *
 
       - name: Init gradle project
-        run: ./gradlew clean --info --stacktrace
+        run: ./gradlew clean --scan
 
       - name: Build mirai-core series
-        run: ./gradlew assemble --info --stacktrace
+        run: ./gradlew assemble --scan
 
       - name: mirai-core Tests
-        run: ./gradlew check --info --stacktrace
+        run: ./gradlew check --scan
 
   build-all:
     runs-on: ubuntu-latest
@@ -45,10 +45,10 @@ jobs:
         run: chmod -R 777 *
 
       - name: Init gradle project
-        run: ./gradlew clean --info --stacktrace
+        run: ./gradlew clean --scan
 
       - name: Build all
-        run: ./gradlew assemble --info --stacktrace
+        run: ./gradlew assemble --scan
 
       - name: All Tests
-        run: ./gradlew check --info --stacktrace
+        run: ./gradlew check --scan

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,11 @@ tasks.register("cleanExceptIntellij") {
     }
 }
 
+extensions.findByName("buildScan")?.withGroovyBuilder {
+    setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
+    setProperty("termsOfServiceAgree", "yes")
+}
+
 fun Project.useIr() {
     kotlinCompilations?.forEach { kotlinCompilation ->
         kotlinCompilation.kotlinOptions.freeCompilerArgs += "-Xuse-ir"


### PR DESCRIPTION
Hi, 我是Gradle团队的，无意中看到这个框架，非常钦佩作者的才华和能力。

现在的workflows使用的都是`--info --stacktrace`，看log很不方便，改成Gradle的公开build scan——一会看下效果就知道了。

另外现在的构建脚本其实写的不算好，如不嫌弃，有机会我会重构一下。

