### PR TITLE
fix: serialization plugin should not be put into runtime classpath

### DIFF
--- a/mirai-core-api/build.gradle.kts
+++ b/mirai-core-api/build.gradle.kts
@@ -54,7 +54,6 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":mirai-core-utils"))
-                api(kotlin("serialization"))
                 api(kotlin("reflect"))
 
                 api(`kotlinx-serialization-core`)

--- a/mirai-core-utils/build.gradle.kts
+++ b/mirai-core-utils/build.gradle.kts
@@ -52,7 +52,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(kotlin("serialization"))
                 api(kotlin("reflect"))
 
                 api1(`kotlinx-serialization-core`)


### PR DESCRIPTION
引用`serialization`只需要 `kotlinx-serialization-core` / `kotlinx-serialization-json` / `kotlinx-serialization-protobuf` 等指令
`api(kotlin("serialization"))` 实际上引用的是**编译器插件**（并且还会向外传播污染其他项目），编译器插件不应该放到runtime classpath中
即使是用`compileOnly`也没用，在`dependencies`里引用编译器插件不会被`apply`的，编译器插件只应该在`buildscript`段或`plugin`段中被引用

![ZipTree of mirai-core-all](https://user-images.githubusercontent.com/73171532/115112011-de281d80-9fb5-11eb-9183-6282d8a4446d.png)
