### PR TITLE
Remove redundant spaces in rendering ForwardMessage

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/message/data/ForwardMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/ForwardMessage.kt
@@ -81,7 +81,7 @@ public data class RawForwardMessage(
  * | <消息 2>                 |
  * | <消息 3>                 |
  * |-------------------------|
- * | 查看 3 条转发消息          |
+ * | 查看3条转发消息          |
  * |-------------------------|
  * ```
  *
@@ -151,7 +151,7 @@ public data class ForwardMessage(
         /**
          * 显示在卡片底部
          */
-        public fun generateSummary(forward: RawForwardMessage): String = "查看 ${forward.nodeList.size} 条转发消息"
+        public fun generateSummary(forward: RawForwardMessage): String = "查看${forward.nodeList.size}条转发消息"
 
         /**
          * 默认的, 与官方客户端相似的展示方案.


### PR DESCRIPTION
![Screenshot_20210522_225655](https://user-images.githubusercontent.com/29498336/119250305-c43fb300-bbd1-11eb-95ab-b3afa3420b63.jpg)
此图片的上面的ForwardMessage是由mirai发出的
下面是手机QQ发出的
mirai的ForwardMessage的“查看x条转发消息”在数字处多了空格