### PR TITLE
`Face.toString`: use `contentToString()` for better readability

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/message/data/Face.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Face.kt
@@ -33,7 +33,7 @@ public data class Face(public val id: Int) : // used in delegation
 
     public val name: String get() = contentToString().let { it.substring(1, it.length - 1) }
 
-    override fun toString(): String = serializeToMiraiCode()
+    override fun toString(): String = contentToString()
     override fun contentToString(): String = names.getOrElse(id) { "[表情]" }
 
     @MiraiExperimentalApi


### PR DESCRIPTION
Typical message would be `Someone(123456) -> [mirai:face:111]` before and `Someone(123456) -> [可怜]` now.