### PR TITLE
Introduce `mirai-bom` for dependency management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ jobs:
         run: >
           ./gradlew publish --info --scan
 
+      - name: Gradle :mirai-bom:publish
+        run: >
+          ./gradlew
+          :mirai-bom:publish --info --scan
+
       - name: Publish Gradle plugin
         run: >
           ./gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,6 @@ jobs:
         run: >
           ./gradlew publish --info --scan
 
-      - name: Gradle :mirai-bom:publish
-        run: >
-          ./gradlew
-          :mirai-bom:publish --info --scan
-
       - name: Publish Gradle plugin
         run: >
           ./gradlew

--- a/docs/ConfiguringProjects.md
+++ b/docs/ConfiguringProjects.md
@@ -69,21 +69,21 @@ dependencies {
 
 ### 分离 API 和实现（可选）
 
-mirai 在开发时需要 `net.mamoe:mirai-core-api`, 在运行时需要 `net.mamoe:mirai-core`。可以在开发和编译时只依赖 `mirai-core-api`，会减轻对 IDE 的负担。  
-在新版本中我们添加了 `mirai-bom` 用于自动协调 Mirai 不同组件的版本信息，这是您引用 Mirai 平台的首选方式。  
-使用 `mirai-bom` 也会对 `Dependabot` 等自动化依赖管理程序更加友好
+Mirai 在开发时需要 `net.mamoe:mirai-core-api`, 在运行时需要 `net.mamoe:mirai-core`。可以在开发和编译时只依赖 `mirai-core-api`，会减轻对 IDE 的负担。  
+在 2.8.0 起 Mirai 提供 `mirai-bom` 用于自动协调 Mirai 不同组件的版本信息，这是引用 Mirai 平台的首选方式。
+使用 `mirai-bom` 也会对 Dependabot 等自动化依赖管理程序更加友好。
 ```kotlin
 dependencies {
-    val miraiVersion = "2.7.0"
-    api("net.mamoe", "mirai-core-api", miraiVersion)     // 编译代码使用
-    runtimeOnly("net.mamoe", "mirai-core", miraiVersion) // 运行时使用
+    api(platform("net.mamoe:mirai-bom:2.8.0"))
+    api("net.mamoe:mirai-core-api")     // 编译代码使用
+    runtimeOnly("net.mamoe:mirai-core") // 运行时使用
 }
 ```
-您也可以继续使用传统方式，但务必手动保证 `mirai-core-api` 和 `mirai-core` 的版本号相一致，以避免潜在的异常  
-尤其需要注意的是 `Dependabot` 等依赖管理程序可能会打破组件间版本的一致性  
+也可以继续使用如下传统方式，但务必保证 `mirai-core-api` 和 `mirai-core` 的版本号相一致，以避免潜在的异常。  
+尤其注意 Dependabot 等依赖管理程序可能会导致模块版本不同。
 ```kotlin
 dependencies {
-    val miraiVersion = "2.6.7"
+    val miraiVersion = "2.8.0"
     api("net.mamoe", "mirai-core-api", miraiVersion)     // 编译代码使用
     runtimeOnly("net.mamoe", "mirai-core", miraiVersion) // 运行时使用
 }

--- a/docs/ConfiguringProjects.md
+++ b/docs/ConfiguringProjects.md
@@ -69,7 +69,9 @@ dependencies {
 
 ### 分离 API 和实现（可选）
 
-mirai 在开发时需要 `net.mamoe:mirai-core-api`, 在运行时需要 `net.mamoe:mirai-core`。可以在开发和编译时只依赖 `mirai-core-api`，会减轻对 IDE 的负担。
+mirai 在开发时需要 `net.mamoe:mirai-core-api`, 在运行时需要 `net.mamoe:mirai-core`。可以在开发和编译时只依赖 `mirai-core-api`，会减轻对 IDE 的负担。  
+在新版本中我们添加了 `mirai-bom` 用于自动协调 Mirai 不同组件的版本信息，这是您引用 Mirai 平台的首选方式。  
+使用 `mirai-bom` 也会对 `Dependabot` 等自动化依赖管理程序更加友好
 ```kotlin
 dependencies {
     val miraiVersion = "2.7.0"
@@ -77,7 +79,15 @@ dependencies {
     runtimeOnly("net.mamoe", "mirai-core", miraiVersion) // 运行时使用
 }
 ```
-
+您也可以继续使用传统方式，但务必手动保证 `mirai-core-api` 和 `mirai-core` 的版本号相一致，以避免潜在的异常  
+尤其需要注意的是 `Dependabot` 等依赖管理程序可能会打破组件间版本的一致性  
+```kotlin
+dependencies {
+    val miraiVersion = "2.6.7"
+    api("net.mamoe", "mirai-core-api", miraiVersion)     // 编译代码使用
+    runtimeOnly("net.mamoe", "mirai-core", miraiVersion) // 运行时使用
+}
+```
 
 ## B. 使用 Maven
 

--- a/mirai-bom/build.gradle.kts
+++ b/mirai-bom/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    `java-platform`
+    `maven-publish`
+}
+
+description = "Mirai BOM"
+
+rootProject.subprojects
+    .filter { it.path != project.path }
+    .forEach { project.evaluationDependsOn(it.path) }
+
+dependencies {
+    constraints {
+        rootProject.subprojects
+            .filter { it.path != project.path }
+            .filter { it.extensions.findByName("publishing") != null }
+            .forEach { subProject ->
+                subProject.publishing.publications
+                    .withType<MavenPublication>()
+                    .forEach {
+                        this@constraints.api("${it.groupId}:${it.artifactId}:${it.version}")
+                    }
+            }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("myPlatform") {
+            groupId = rootProject.group.toString()
+            artifactId = "mirai-bom"
+            version = Versions.project
+            from(components["javaPlatform"])
+            setupPom(project)
+            configGpgSign(project)
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(":mirai-core-utils")
 include(":mirai-core-api")
 include(":mirai-core")
 include(":mirai-core-all")
+include(":mirai-bom")
 
 include(":binary-compatibility-validator")
 include(":binary-compatibility-validator-android")


### PR DESCRIPTION
Ref: [Using a platform to control transitive versions](https://docs.gradle.org/current/userguide/platforms.html#sub:using-platform-to-control-transitive-deps)