### PR TITLE
Ensure `SimpleListenerHost.handleException` is called; Cancel registered listeners in `SimpleListenerHost` when it's completed

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/event/EventChannel.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/EventChannel.kt
@@ -479,9 +479,43 @@ public open class EventChannel<out BaseEvent : Event> @JvmOverloads internal con
         host: ListenerHost,
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ) {
+        val cancelHook: Job?
+        val coroutineContext0 = if (host is SimpleListenerHost) {
+            val listenerCoroutineContext = host.coroutineContext
+            val listenerJob = listenerCoroutineContext[Job]
+
+            val rsp = listenerCoroutineContext.minusKey(Job) +
+                    coroutineContext +
+                    (listenerCoroutineContext[CoroutineExceptionHandler] ?: EmptyCoroutineContext)
+
+            val registerCancelHook = when {
+                listenerJob === null -> false
+                (rsp[Job] ?: this.defaultCoroutineContext[Job]) !== listenerJob -> true
+                else -> false
+            }
+
+            cancelHook = if (registerCancelHook) {
+                listenerCoroutineContext[Job]
+            } else {
+                null
+            }
+            rsp
+        } else {
+            cancelHook = null
+            coroutineContext
+        }
         for (method in host.javaClass.declaredMethods) {
             method.getAnnotation(EventHandler::class.java)?.let {
-                method.registerEventHandler(host, this, it, coroutineContext)
+                val listener = method.registerEventHandler(host, this, it, coroutineContext0)
+                cancelHook?.invokeOnCompletion { exception ->
+                    listener.cancel(
+                        when (exception) {
+                            is CancellationException -> exception
+                            is Throwable -> CancellationException(null, exception)
+                            else -> null
+                        }
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
For slove https://mirai.mamoe.net/topic/548/java%E4%B8%AD-simplelistenerhost-handleexception%E5%87%BD%E6%95%B0%E5%B9%B6%E6%B2%A1%E6%9C%89%E8%A2%AB%E6%89%A7%E8%A1%8C