### PR TITLE
修复群联系人缓存保存&删除多余默认登录服务器

### DIFF
--- a/mirai-core/src/commonMain/kotlin/network/QQAndroidClient.kt
+++ b/mirai-core/src/commonMain/kotlin/network/QQAndroidClient.kt
@@ -39,7 +39,7 @@ internal fun getRandomByteArray(length: Int): ByteArray = ByteArray(length) { Ra
 // [114.221.148.179:14000, 113.96.13.125:8080, 14.22.3.51:8080, 42.81.172.207:443, 114.221.144.89:80, 125.94.60.148:14000, 42.81.192.226:443, 114.221.148.233:8080, msfwifi.3g.qq.com:8080, 42.81.172.22:80]
 
 internal val DefaultServerList: MutableSet<Pair<String, Int>> =
-    "msfwifi.3g.qq.com:8080, 14.215.138.110:8080, 113.96.12.224:8080, 157.255.13.77:14000, 120.232.18.27:443, 183.3.235.162:14000, 163.177.89.195:443, 183.232.94.44:80, 203.205.255.224:8080, 203.205.255.221:8080"
+    "msfwifi.3g.qq.com:8080"
         .split(", ")
         .map {
             val host = it.substringBefore(':')

--- a/mirai-core/src/commonMain/kotlin/network/components/ContactUpdater.kt
+++ b/mirai-core/src/commonMain/kotlin/network/components/ContactUpdater.kt
@@ -28,7 +28,6 @@ import net.mamoe.mirai.internal.contact.info.GroupInfoImpl
 import net.mamoe.mirai.internal.contact.info.MemberInfoImpl
 import net.mamoe.mirai.internal.contact.info.StrangerInfoImpl
 import net.mamoe.mirai.internal.contact.toMiraiFriendInfo
-import net.mamoe.mirai.internal.network.GroupMemberListCache
 import net.mamoe.mirai.internal.network.Packet
 import net.mamoe.mirai.internal.network.component.ComponentKey
 import net.mamoe.mirai.internal.network.component.ComponentStorage

--- a/mirai-core/src/commonMain/kotlin/network/components/ContactUpdater.kt
+++ b/mirai-core/src/commonMain/kotlin/network/components/ContactUpdater.kt
@@ -28,6 +28,7 @@ import net.mamoe.mirai.internal.contact.info.GroupInfoImpl
 import net.mamoe.mirai.internal.contact.info.MemberInfoImpl
 import net.mamoe.mirai.internal.contact.info.StrangerInfoImpl
 import net.mamoe.mirai.internal.contact.toMiraiFriendInfo
+import net.mamoe.mirai.internal.network.GroupMemberListCache
 import net.mamoe.mirai.internal.network.Packet
 import net.mamoe.mirai.internal.network.component.ComponentKey
 import net.mamoe.mirai.internal.network.component.ComponentStorage
@@ -201,6 +202,7 @@ internal class ContactUpdaterImpl(
             } else refreshGroupMemberList().also { sequence ->
                 cache.troopMemberNumSeq = dwMemberNumSeq ?: 0
                 cache.list = sequence.mapTo(ArrayList()) { it as MemberInfoImpl }
+                cacheService.groupMemberListCaches!!.map[groupCode] = cache
                 cacheService.groupMemberListCaches!!.reportChanged(groupCode)
             }
         } else {

--- a/mirai-core/src/commonMain/kotlin/network/components/ServerList.kt
+++ b/mirai-core/src/commonMain/kotlin/network/components/ServerList.kt
@@ -86,10 +86,7 @@ internal interface ServerList {
 
     companion object : ComponentKey<ServerList> {
         val DEFAULT_SERVER_LIST: Set<ServerAddress> =
-            """msfwifi.3g.qq.com:8080, 14.215.138.110:8080, 113.96.12.224:8080,
-                |157.255.13.77:14000, 120.232.18.27:443, 
-                |183.3.235.162:14000, 163.177.89.195:443, 183.232.94.44:80, 
-                |203.205.255.224:8080, 203.205.255.221:8080""".trimMargin()
+            """msfwifi.3g.qq.com:8080""".trimMargin()
                 .splitToSequence(",").filterNot(String::isBlank)
                 .map { it.trim() }
                 .map {


### PR DESCRIPTION
ContactListCache.kt中的takeCurrentChangedGroups方法
会移除changedGroups中的cache,而get方法会直接把本地文件的老的缓存放进去
所以会出现缓存保存失败
将cache重新添加回去即可保存新的缓存,而不是再次保存过期的缓存
https://github.com/mamoe/mirai/issues/1625
已运行测试,缓存保存成功