### PR TITLE
修复群ID构造的图片发送缓慢,以及无法添加到ForwardMessage中

### DIFF
--- a/mirai-core/src/commonMain/kotlin/message/imagesImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/message/imagesImpl.kt
@@ -337,7 +337,7 @@ internal data class OfflineGroupImage(
     override val imageType: ImageType = ImageType.UNKNOWN
 ) : GroupImage(), OfflineImage, DeferredOriginUrlAware {
     @Transient
-    internal var fileId: Int? = null
+    internal var fileId: Int? = -1
 
     object Serializer : Image.FallbackSerializer("OfflineGroupImage")
 


### PR DESCRIPTION
修复前：发送由ID构造的图片到群内需要调用GroupPicUp(发送缓慢),私聊却不会,修改为闪照在群内发送也不会
并且添加到ForwardMessage中会无法显示

修复后: ID构造的图片在群内发送不会调用GroupPicUp，跟私聊和闪照时一样，秒发,并且可以添加到ForwardMessage中
只有upload的时候会调用GroupPicUp,用户也可以自行实现ExternalResource检查图片是否过期

其实主要是因为本人写了个涩图插件，用图片ID的方式储存图片，并不需要任何的API获取图片链接下载，或读取本地的文件，主要是为了速度快，已经测试过构造50个图片ID的ForwardMessage 1秒发送完成,机器人发送消息,接收消息
发送离线ID构造的图片，发送upload的图片,发送闪照都是正常的
并且fileID的可见性为internal,也就是其他模块不可调用,修改后不会对其他使用miria的项目造成影响

此次修改内容构造的mirai和插件已经发送给多人进行测试,未发现任何问题

