### PR TITLE
修复设置 redirectNetworkLogToDirectory 后日志 identity 为 Bot 的问题

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/utils/BotConfiguration.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/BotConfiguration.kt
@@ -408,7 +408,7 @@ public open class BotConfiguration { // open for Java
     @ConfigurationDsl
     public fun redirectBotLogToFile(
         file: File = File("mirai.log"),
-        identity: (bot: Bot) -> String = { "Net ${it.id}" }
+        identity: (bot: Bot) -> String = { "Bot ${it.id}" }
     ) {
         require(!file.isDirectory) { "file must not be a dir" }
         botLoggerSupplier = { SingleFileLogger(identity(it), workingDir.resolve(file)) }
@@ -425,7 +425,7 @@ public open class BotConfiguration { // open for Java
     public fun redirectBotLogToDirectory(
         dir: File = File("logs"),
         retain: Long = 1.weeksToMillis,
-        identity: (bot: Bot) -> String = { "Net ${it.id}" }
+        identity: (bot: Bot) -> String = { "Bot ${it.id}" }
     ) {
         require(!dir.isFile) { "dir must not be a file" }
         botLoggerSupplier = { DirectoryLogger(identity(it), workingDir.resolve(dir), retain) }


### PR DESCRIPTION
Fix #1743