### PR TITLE
Review deprecation for 2.10. close #1742

### DIFF
--- a/logging/mirai-logging-log4j2/test/MiraiLog4JAdapterTest.kt
+++ b/logging/mirai-logging-log4j2/test/MiraiLog4JAdapterTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertIs
 
 internal class MiraiLog4JAdapterTest {
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Test
     fun `services prevail than legacy overrides`() {
         MiraiLogger.setDefaultLoggerCreator {

--- a/mirai-console/backend/codegen/src/MessageScopeCodegen.kt
+++ b/mirai-console/backend/codegen/src/MessageScopeCodegen.kt
@@ -164,7 +164,7 @@ internal object MessageScopeCodegen {
                     @Deprecated(
                         "Senseless scopeWith. Use asMessageScope.",
                         ReplaceWith("this.asMessageScope()", "net.mamoe.mirai.console.util.asMessageScope")
-                    )
+                    ) // diagnostic deprecation
                     public inline fun ${a}.scopeWith(): MessageScope = asMessageScope()
                 """
                 )
@@ -181,7 +181,7 @@ internal object MessageScopeCodegen {
                             "net.mamoe.mirai.console.util.asMessageScope", 
                             "net.mamoe.mirai.console.util.invoke",
                         )
-                    )
+                    ) // diagnostic deprecation
                     public inline fun <R> ${a}.scopeWith(action: MessageScope.() -> R): R = asMessageScope()(action)
 """
                 )

--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -2341,7 +2341,7 @@ public abstract interface class net/mamoe/mirai/console/plugin/PluginFileExtensi
 public final class net/mamoe/mirai/console/plugin/PluginKt {
 	public static final fun getAuthor (Lnet/mamoe/mirai/console/plugin/Plugin;)Ljava/lang/String;
 	public static final fun getDependencies (Lnet/mamoe/mirai/console/plugin/Plugin;)Ljava/util/Set;
-	public static final fun getDescription (Lnet/mamoe/mirai/console/plugin/Plugin;)Lnet/mamoe/mirai/console/plugin/description/PluginDescription;
+	public static final synthetic fun getDescription (Lnet/mamoe/mirai/console/plugin/Plugin;)Lnet/mamoe/mirai/console/plugin/description/PluginDescription;
 	public static final fun getId (Lnet/mamoe/mirai/console/plugin/Plugin;)Ljava/lang/String;
 	public static final fun getInfo (Lnet/mamoe/mirai/console/plugin/Plugin;)Ljava/lang/String;
 	public static final fun getName (Lnet/mamoe/mirai/console/plugin/Plugin;)Ljava/lang/String;

--- a/mirai-console/backend/mirai-console/src/command/CommandSender.kt
+++ b/mirai-console/backend/mirai-console/src/command/CommandSender.kt
@@ -37,6 +37,7 @@ import net.mamoe.mirai.message.data.Message
 import net.mamoe.mirai.message.data.PlainText
 import net.mamoe.mirai.utils.childScope
 import net.mamoe.mirai.utils.childScopeContext
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -589,8 +590,9 @@ public open class MemberCommandSender internal constructor(
 @Deprecated(
     "mirai 正计划支持其他渠道发起的临时会话, 届时此事件会变动. 原 TempCommandSender 已更改为 GroupTempCommandSender",
     replaceWith = ReplaceWith("GroupTempCommandSender", "net.mamoe.mirai.console.command.GroupTempCommandSender"),
-    DeprecationLevel.ERROR
+    DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
 public sealed class TempCommandSender(
     public override val user: NormalMember,
 ) : AbstractUserCommandSender(), GroupAwareCommandSender, CoroutineScope by user.childScope("TempCommandSender")
@@ -705,8 +707,9 @@ public class MemberCommandSenderOnMessage internal constructor(
         "GroupTempCommandSenderOnMessage",
         "net.mamoe.mirai.console.command.GroupTempCommandSenderOnMessage"
     ),
-    DeprecationLevel.ERROR
+    DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
 public sealed class TempCommandSenderOnMessage(
     public override val fromEvent: GroupTempMessageEvent,
 ) : GroupTempCommandSender(fromEvent.sender), CommandSenderOnMessage<GroupTempMessageEvent>

--- a/mirai-console/backend/mirai-console/src/data/PluginDataExtensions.kt
+++ b/mirai-console/backend/mirai-console/src/data/PluginDataExtensions.kt
@@ -14,6 +14,7 @@ package net.mamoe.mirai.console.data
 import net.mamoe.mirai.console.data.PluginDataExtensions.withDefault
 import net.mamoe.mirai.console.internal.data.ShadowMap
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import kotlin.internal.LowPriorityInOverloadResolution
 
 /**
@@ -32,7 +33,7 @@ public object PluginDataExtensions {
             "getOrDefault on NotNullMap always returns the value in the map, and defaultValue will never be returned.",
             level = DeprecationLevel.WARNING,
             replaceWith = ReplaceWith("this.get(key)")
-        )
+        ) // diagnostic deprecation
         override fun getOrDefault(key: K, defaultValue: V): V {
             return super.getOrDefault(key, defaultValue)
         }
@@ -49,7 +50,7 @@ public object PluginDataExtensions {
             "getOrDefault on NotNullMutableMap always returns the value in the map, and defaultValue will never be returned.",
             level = DeprecationLevel.WARNING,
             replaceWith = ReplaceWith("this.get(key)")
-        )
+        ) // diagnostic deprecation
         override fun getOrDefault(key: K, defaultValue: V): V {
             return super<MutableMap>.getOrDefault(key, defaultValue)
         }
@@ -58,7 +59,7 @@ public object PluginDataExtensions {
             "putIfAbsent on NotNullMutableMap always does nothing.",
             level = DeprecationLevel.WARNING,
             replaceWith = ReplaceWith("")
-        )
+        ) // diagnostic deprecation
         override fun putIfAbsent(key: K, value: V): Nothing? = null
     }
 

--- a/mirai-console/backend/mirai-console/src/internal/util/CommonUtils.kt
+++ b/mirai-console/backend/mirai-console/src/internal/util/CommonUtils.kt
@@ -50,7 +50,7 @@ internal inline fun <T : Any> T?.ifNull(block: () -> T): T {
 }
 
 @Suppress("DeprecatedCallableAddReplaceWith", "UnusedParameter", "UNUSED_PARAMETER")
-@Deprecated("Useless ifNull on not null value.")
+@Deprecated("Useless ifNull on not null value.") // diagnostic deprecation
 @JvmName("ifNull1")
 internal inline fun <T : Any> T.ifNull(block: () -> T): T = this
 

--- a/mirai-console/backend/mirai-console/src/permission/PermitteeId.kt
+++ b/mirai-console/backend/mirai-console/src/permission/PermitteeId.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.console.internal.permission.parseFromStringImpl
 import net.mamoe.mirai.console.permission.AbstractPermitteeId.*
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
 import net.mamoe.mirai.contact.*
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 
 /**
@@ -275,8 +276,9 @@ public sealed class AbstractPermitteeId(
     @Deprecated(
         "use AnyGroupTemp",
         ReplaceWith("AnyGroupTemp", "net.mamoe.mirai.console.permission.AbstractPermitteeId.AnyGroupTemp"),
-        DeprecationLevel.ERROR
+        DeprecationLevel.HIDDEN
     )
+    @DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
     public abstract class AnyTemp(
         groupId: Long,
     ) : AbstractPermitteeId(AnyMember(groupId), AnyTempFromAnyGroup)
@@ -308,8 +310,9 @@ public sealed class AbstractPermitteeId(
     @Deprecated(
         "use ExactGroupTemp",
         ReplaceWith("ExactGroupTemp", "net.mamoe.mirai.console.permission.AbstractPermitteeId.ExactGroupTemp"),
-        DeprecationLevel.ERROR
+        DeprecationLevel.HIDDEN
     )
+    @DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
     public abstract class ExactTemp internal constructor(
         groupId: Long,
         memberId: Long,

--- a/mirai-console/backend/mirai-console/src/plugin/Plugin.kt
+++ b/mirai-console/backend/mirai-console/src/plugin/Plugin.kt
@@ -18,7 +18,9 @@ import net.mamoe.mirai.console.plugin.description.PluginDescription
 import net.mamoe.mirai.console.plugin.jvm.JvmPlugin
 import net.mamoe.mirai.console.plugin.loader.PluginLoader
 import net.mamoe.mirai.console.util.SemVersion
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import kotlin.DeprecationLevel.ERROR
+import kotlin.DeprecationLevel.HIDDEN
 
 /**
  * 表示一个 mirai-console 插件.
@@ -53,8 +55,9 @@ public interface Plugin : CommandOwner {
 @Deprecated(
     "Moved to companion for a better Java API. ",
     ReplaceWith("this.description", "net.mamoe.mirai.console.plugin.PluginManager.INSTANCE.description"),
-    level = ERROR
+    level = HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
 public inline val Plugin.description: PluginDescription
     get() = getPluginDescription(this) // resolved to net.mamoe.mirai.console.plugin.PluginManager.INSTANCE.getDescription
 

--- a/mirai-console/backend/mirai-console/src/util/MessageScope.kt
+++ b/mirai-console/backend/mirai-console/src/util/MessageScope.kt
@@ -328,19 +328,19 @@ public inline fun <R> MessageScope?.scopeWith(vararg others: MessageScope?, acti
 @Deprecated(
     "Senseless scopeWith. Use asMessageScope.",
     ReplaceWith("this.asMessageScope()", "net.mamoe.mirai.console.util.asMessageScope")
-)
+) // diagnostic deprecation
 public inline fun Contact.scopeWith(): MessageScope = asMessageScope()
 
 @Deprecated(
     "Senseless scopeWith. Use asMessageScope.",
     ReplaceWith("this.asMessageScope()", "net.mamoe.mirai.console.util.asMessageScope")
-)
+) // diagnostic deprecation
 public inline fun CommandSender.scopeWith(): MessageScope = asMessageScope()
 
 @Deprecated(
     "Senseless scopeWith. Use asMessageScope.",
     ReplaceWith("this.asMessageScope()", "net.mamoe.mirai.console.util.asMessageScope")
-)
+) // diagnostic deprecation
 public inline fun MessageScope.scopeWith(): MessageScope = asMessageScope()
 
 @Deprecated(
@@ -348,9 +348,9 @@ public inline fun MessageScope.scopeWith(): MessageScope = asMessageScope()
     ReplaceWith(
         "this.asMessageScope()(action)",
         "net.mamoe.mirai.console.util.asMessageScope",
-        "net.mamoe.mirai.console.util.invoke"
+        "net.mamoe.mirai.console.util.invoke",
     )
-)
+) // diagnostic deprecation
 public inline fun <R> Contact.scopeWith(action: MessageScope.() -> R): R = asMessageScope()(action)
 
 @Deprecated(
@@ -358,9 +358,9 @@ public inline fun <R> Contact.scopeWith(action: MessageScope.() -> R): R = asMes
     ReplaceWith(
         "this.asMessageScope()(action)",
         "net.mamoe.mirai.console.util.asMessageScope",
-        "net.mamoe.mirai.console.util.invoke"
+        "net.mamoe.mirai.console.util.invoke",
     )
-)
+) // diagnostic deprecation
 public inline fun <R> CommandSender.scopeWith(action: MessageScope.() -> R): R = asMessageScope()(action)
 
 @Deprecated(
@@ -368,9 +368,9 @@ public inline fun <R> CommandSender.scopeWith(action: MessageScope.() -> R): R =
     ReplaceWith(
         "this.asMessageScope()(action)",
         "net.mamoe.mirai.console.util.asMessageScope",
-        "net.mamoe.mirai.console.util.invoke"
+        "net.mamoe.mirai.console.util.invoke",
     )
-)
+) // diagnostic deprecation
 public inline fun <R> MessageScope.scopeWith(action: MessageScope.() -> R): R = asMessageScope()(action)
 
 //// endregion MessageScopeBuilders CODEGEN ////

--- a/mirai-console/frontend/mirai-console-terminal/build.gradle.kts
+++ b/mirai-console/frontend/mirai-console-terminal/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
 dependencies {
     implementation("org.jline:jline:3.15.0")
     implementation("org.fusesource.jansi:jansi:1.18")
+    compileAndTestRuntime(project(":mirai-core-utils"))
 
     compileAndTestRuntime(project(":mirai-console"))
     compileAndTestRuntime(project(":mirai-core-api"))

--- a/mirai-console/frontend/mirai-console-terminal/src/net/mamoe/mirai/console/pure/MiraiConsolePureLoader.kt
+++ b/mirai-console/frontend/mirai-console-terminal/src/net/mamoe/mirai/console/pure/MiraiConsolePureLoader.kt
@@ -10,21 +10,24 @@
 package net.mamoe.mirai.console.terminal.net.mamoe.mirai.console.pure
 
 import net.mamoe.mirai.console.terminal.MiraiConsoleTerminalLoader
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 
 @Deprecated(
     message = "Please use MiraiConsoleTerminalLoader",
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.HIDDEN,
     replaceWith = ReplaceWith(
         "MiraiConsoleTerminalLoader",
         "net.mamoe.mirai.console.terminal.MiraiConsoleTerminalLoader"
     )
 )
+@DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
 object MiraiConsolePureLoader {
     @Deprecated(
         message = "for binary compatibility",
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     @JvmStatic
+    @DeprecatedSinceMirai(errorSince = "2.0", hiddenSince = "2.10")
     fun main(args: Array<String>) {
         System.err.println("WARNING: Mirai Console Pure已经更名为 Mirai Console Terminal")
         System.err.println("请使用新的入口点 net.mamoe.mirai.console.terminal.MiraiConsoleTerminalLoader")

--- a/mirai-console/tools/gradle-plugin/src/main/kotlin/MiraiConsoleExtension.kt
+++ b/mirai-console/tools/gradle-plugin/src/main/kotlin/MiraiConsoleExtension.kt
@@ -278,7 +278,7 @@ public open class MiraiConsoleExtension {
          * 自定义配置 [BintrayExtension]，覆盖
          */
         @Suppress("DeprecatedCallableAddReplaceWith")
-        @Deprecated("不再支持发布到 bintray. 该配置会在 2.8 删除.", level = DeprecationLevel.WARNING)
+        @Deprecated("不再支持发布到 bintray. 该配置会在 2.8 删除.", level = DeprecationLevel.ERROR)
         public fun bintray(configure: BintrayExtension.() -> Unit) {
             bintrayConfigs.add(configure)
         }
@@ -287,7 +287,7 @@ public open class MiraiConsoleExtension {
          * 自定义配置 [BintrayExtension.PackageConfig]
          */
         @Suppress("DeprecatedCallableAddReplaceWith")
-        @Deprecated("不再支持发布到 bintray. 该配置会在 2.8 删除.", level = DeprecationLevel.WARNING)
+        @Deprecated("不再支持发布到 bintray. 该配置会在 2.8 删除.", level = DeprecationLevel.ERROR)
         public fun packageConfig(configure: BintrayExtension.PackageConfig.() -> Unit) {
             bintrayPackageConfigConfigs.add(configure)
         }

--- a/mirai-core-api/compatibility-validation/android/api/android.api
+++ b/mirai-core-api/compatibility-validation/android/api/android.api
@@ -5670,7 +5670,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun getContactListCache ()Lnet/mamoe/mirai/utils/BotConfiguration$ContactListCache;
 	public static final fun getDefault ()Lnet/mamoe/mirai/utils/BotConfiguration;
 	public final fun getDeviceInfo ()Lkotlin/jvm/functions/Function1;
-	public final fun getFirstReconnectDelayMillis ()J
+	public final synthetic fun getFirstReconnectDelayMillis ()J
 	public final fun getHeartbeatPeriodMillis ()J
 	public final fun getHeartbeatStrategy ()Lnet/mamoe/mirai/utils/BotConfiguration$HeartbeatStrategy;
 	public final fun getHeartbeatTimeoutMillis ()J
@@ -5681,7 +5681,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun getNetworkLoggerSupplier ()Lkotlin/jvm/functions/Function1;
 	public final fun getParentCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getProtocol ()Lnet/mamoe/mirai/utils/BotConfiguration$MiraiProtocol;
-	public final fun getReconnectPeriodMillis ()J
+	public final synthetic fun getReconnectPeriodMillis ()J
 	public final fun getReconnectionRetryTimes ()I
 	public final fun getStatHeartbeatPeriodMillis ()J
 	public final fun getWorkingDir ()Ljava/io/File;
@@ -5716,7 +5716,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun setContactListCache (Lnet/mamoe/mirai/utils/BotConfiguration$ContactListCache;)V
 	public final fun setConvertLineSeparator (Z)V
 	public final fun setDeviceInfo (Lkotlin/jvm/functions/Function1;)V
-	public final fun setFirstReconnectDelayMillis (J)V
+	public final synthetic fun setFirstReconnectDelayMillis (J)V
 	public final fun setHeartbeatPeriodMillis (J)V
 	public final fun setHeartbeatStrategy (Lnet/mamoe/mirai/utils/BotConfiguration$HeartbeatStrategy;)V
 	public final fun setHeartbeatTimeoutMillis (J)V
@@ -5727,7 +5727,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun setNetworkLoggerSupplier (Lkotlin/jvm/functions/Function1;)V
 	public final fun setParentCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setProtocol (Lnet/mamoe/mirai/utils/BotConfiguration$MiraiProtocol;)V
-	public final fun setReconnectPeriodMillis (J)V
+	public final synthetic fun setReconnectPeriodMillis (J)V
 	public final fun setReconnectionRetryTimes (I)V
 	public final fun setShowingVerboseEventLog (Z)V
 	public final fun setStatHeartbeatPeriodMillis (J)V
@@ -5882,7 +5882,6 @@ public abstract interface class net/mamoe/mirai/utils/ExternalResource : java/io
 	public static fun create (Ljava/io/RandomAccessFile;Ljava/lang/String;Z)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static fun create ([B)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static fun create ([BLjava/lang/String;)Lnet/mamoe/mirai/utils/ExternalResource;
-	public static fun createAutoCloseable (Lnet/mamoe/mirai/utils/ExternalResource;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public abstract fun getClosed ()Lkotlinx/coroutines/Deferred;
 	public abstract fun getFormatName ()Ljava/lang/String;
 	public abstract fun getMd5 ()[B
@@ -5947,7 +5946,6 @@ public final class net/mamoe/mirai/utils/ExternalResource$Companion {
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;Ljava/io/InputStream;Ljava/lang/String;ILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;Ljava/io/RandomAccessFile;Ljava/lang/String;ZILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;[BLjava/lang/String;ILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
-	public final fun createAutoCloseable (Lnet/mamoe/mirai/utils/ExternalResource;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;)Lnet/mamoe/mirai/message/MessageReceipt;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;Lnet/mamoe/mirai/utils/RemoteFile$ProgressionCallback;)Lnet/mamoe/mirai/message/MessageReceipt;

--- a/mirai-core-api/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-core-api/compatibility-validation/jvm/api/jvm.api
@@ -5670,7 +5670,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun getContactListCache ()Lnet/mamoe/mirai/utils/BotConfiguration$ContactListCache;
 	public static final fun getDefault ()Lnet/mamoe/mirai/utils/BotConfiguration;
 	public final fun getDeviceInfo ()Lkotlin/jvm/functions/Function1;
-	public final fun getFirstReconnectDelayMillis ()J
+	public final synthetic fun getFirstReconnectDelayMillis ()J
 	public final fun getHeartbeatPeriodMillis ()J
 	public final fun getHeartbeatStrategy ()Lnet/mamoe/mirai/utils/BotConfiguration$HeartbeatStrategy;
 	public final fun getHeartbeatTimeoutMillis ()J
@@ -5681,7 +5681,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun getNetworkLoggerSupplier ()Lkotlin/jvm/functions/Function1;
 	public final fun getParentCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getProtocol ()Lnet/mamoe/mirai/utils/BotConfiguration$MiraiProtocol;
-	public final fun getReconnectPeriodMillis ()J
+	public final synthetic fun getReconnectPeriodMillis ()J
 	public final fun getReconnectionRetryTimes ()I
 	public final fun getStatHeartbeatPeriodMillis ()J
 	public final fun getWorkingDir ()Ljava/io/File;
@@ -5716,7 +5716,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun setContactListCache (Lnet/mamoe/mirai/utils/BotConfiguration$ContactListCache;)V
 	public final fun setConvertLineSeparator (Z)V
 	public final fun setDeviceInfo (Lkotlin/jvm/functions/Function1;)V
-	public final fun setFirstReconnectDelayMillis (J)V
+	public final synthetic fun setFirstReconnectDelayMillis (J)V
 	public final fun setHeartbeatPeriodMillis (J)V
 	public final fun setHeartbeatStrategy (Lnet/mamoe/mirai/utils/BotConfiguration$HeartbeatStrategy;)V
 	public final fun setHeartbeatTimeoutMillis (J)V
@@ -5727,7 +5727,7 @@ public class net/mamoe/mirai/utils/BotConfiguration {
 	public final fun setNetworkLoggerSupplier (Lkotlin/jvm/functions/Function1;)V
 	public final fun setParentCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setProtocol (Lnet/mamoe/mirai/utils/BotConfiguration$MiraiProtocol;)V
-	public final fun setReconnectPeriodMillis (J)V
+	public final synthetic fun setReconnectPeriodMillis (J)V
 	public final fun setReconnectionRetryTimes (I)V
 	public final fun setShowingVerboseEventLog (Z)V
 	public final fun setStatHeartbeatPeriodMillis (J)V
@@ -5882,7 +5882,6 @@ public abstract interface class net/mamoe/mirai/utils/ExternalResource : java/io
 	public static fun create (Ljava/io/RandomAccessFile;Ljava/lang/String;Z)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static fun create ([B)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static fun create ([BLjava/lang/String;)Lnet/mamoe/mirai/utils/ExternalResource;
-	public static fun createAutoCloseable (Lnet/mamoe/mirai/utils/ExternalResource;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public abstract fun getClosed ()Lkotlinx/coroutines/Deferred;
 	public abstract fun getFormatName ()Ljava/lang/String;
 	public abstract fun getMd5 ()[B
@@ -5947,7 +5946,6 @@ public final class net/mamoe/mirai/utils/ExternalResource$Companion {
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;Ljava/io/InputStream;Ljava/lang/String;ILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;Ljava/io/RandomAccessFile;Ljava/lang/String;ZILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public static synthetic fun create$default (Lnet/mamoe/mirai/utils/ExternalResource$Companion;[BLjava/lang/String;ILjava/lang/Object;)Lnet/mamoe/mirai/utils/ExternalResource;
-	public final fun createAutoCloseable (Lnet/mamoe/mirai/utils/ExternalResource;)Lnet/mamoe/mirai/utils/ExternalResource;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;)Lnet/mamoe/mirai/message/MessageReceipt;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun sendAsFile (Lnet/mamoe/mirai/utils/ExternalResource;Lnet/mamoe/mirai/contact/FileSupported;Ljava/lang/String;Lnet/mamoe/mirai/utils/RemoteFile$ProgressionCallback;)Lnet/mamoe/mirai/message/MessageReceipt;

--- a/mirai-core-api/src/androidMain/kotlin/utils/LoginSolver.android.kt
+++ b/mirai-core-api/src/androidMain/kotlin/utils/LoginSolver.android.kt
@@ -71,6 +71,7 @@ public actual abstract class LoginSolver public actual constructor() {
 
         @Suppress("unused")
         @Deprecated("Binary compatibility", level = DeprecationLevel.HIDDEN)
+        @DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
         public actual fun getDefault(): LoginSolver = Default
             ?: error("LoginSolver is not provided by default on your platform. Please specify by BotConfiguration.loginSolver")
     }

--- a/mirai-core-api/src/commonMain/kotlin/contact/AnonymousMember.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/AnonymousMember.kt
@@ -31,11 +31,11 @@ public interface AnonymousMember : Member {
     /** 该匿名群成员 ID */
     public val anonymousId: String
 
-    @Deprecated(level = DeprecationLevel.ERROR, message = "无法发送信息至 AnonymousMember")
+    @Deprecated(level = DeprecationLevel.ERROR, message = "无法发送信息至 AnonymousMember") // diagnostic deprecation
     public override suspend fun sendMessage(message: Message): Nothing =
         throw UnsupportedOperationException("Cannot send message to AnonymousMember")
 
-    @Deprecated(level = DeprecationLevel.ERROR, message = "无法发送信息至 AnonymousMember")
+    @Deprecated(level = DeprecationLevel.ERROR, message = "无法发送信息至 AnonymousMember") // diagnostic deprecation
     public override suspend fun sendMessage(message: String): Nothing =
         throw UnsupportedOperationException("Cannot send message to AnonymousMember")
 

--- a/mirai-core-api/src/commonMain/kotlin/contact/Exceptions.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/Exceptions.kt
@@ -49,7 +49,7 @@ public class BotIsBeingMutedException @MiraiInternalApi constructor(
     public override val target: Group,
     originalMessage: Message,
 ) : SendMessageFailedException(target, Reason.BOT_MUTED, originalMessage) {
-    @DeprecatedSinceMirai("2.9")
+    @DeprecatedSinceMirai(warningSince = "2.9")
     @Deprecated("Deprecated without replacement. Please consider copy this exception to your code.")
     // this constructor is since 2.0
     public constructor(

--- a/mirai-core-api/src/commonMain/kotlin/contact/FileSupported.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/FileSupported.kt
@@ -11,6 +11,7 @@
 package net.mamoe.mirai.contact
 
 import net.mamoe.mirai.contact.file.RemoteFiles
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.NotStableForInheritance
 
 /**
@@ -31,6 +32,7 @@ public interface FileSupported : Contact {
      */
     @Suppress("DEPRECATION")
     @Deprecated("Please use files instead.", replaceWith = ReplaceWith("files.root")) // deprecated since 2.8.0-RC
+    @DeprecatedSinceMirai(warningSince = "2.8")
     public val filesRoot: net.mamoe.mirai.utils.RemoteFile
 
     /**

--- a/mirai-core-api/src/commonMain/kotlin/contact/Group.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/Group.kt
@@ -19,6 +19,7 @@ import net.mamoe.mirai.contact.announcement.Announcements
 import net.mamoe.mirai.event.events.*
 import net.mamoe.mirai.message.MessageReceipt
 import net.mamoe.mirai.message.data.*
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.ExternalResource
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 import net.mamoe.mirai.utils.NotStableForInheritance
@@ -187,12 +188,13 @@ public interface Group : Contact, CoroutineScope, FileSupported, AudioSupported 
     /**
      * 上传一个语音消息以备发送. 该方法已弃用且将在未来版本删除, 请使用 [uploadAudio].
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     @Deprecated(
         "use uploadAudio",
         replaceWith = ReplaceWith("uploadAudio(resource)"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     ) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun uploadVoice(resource: ExternalResource): Voice
 
     /**
@@ -238,9 +240,10 @@ public interface GroupSettings {
      * @see Group.announcements
      */
     @Deprecated(
-        level = DeprecationLevel.WARNING,
+        level = DeprecationLevel.ERROR,
         message = "group.announcements.asFlow().filter { it.parameters.sendToNewMember }.firstOrNull()",
     ) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public var entranceAnnouncement: String
 
     /**

--- a/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.message.action.Nudge
 import net.mamoe.mirai.message.data.Message
 import net.mamoe.mirai.message.data.isContentEmpty
 import net.mamoe.mirai.message.data.toPlainText
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.NotStableForInheritance
 import kotlin.time.Duration
 import kotlin.time.DurationUnit

--- a/mirai-core-api/src/commonMain/kotlin/data/GroupHonorListData.kt
+++ b/mirai-core-api/src/commonMain/kotlin/data/GroupHonorListData.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 
 /**
@@ -107,16 +108,18 @@ public data class GroupHonorListData(
 
     @Deprecated(
         message = "Meaningless response",
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
         replaceWith = ReplaceWith("error(\"Delete me\")"),
     )
+    @DeprecatedSinceMirai(errorSince = "2.7", hiddenSince = "2.10") // maybe 2.7
     @Suppress("DEPRECATION_ERROR")
     val acceptLanguages: List<Language?>? get() = null
 
     @Deprecated(
         message = "Meaningless response",
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
     )
+    @DeprecatedSinceMirai(errorSince = "2.7", hiddenSince = "2.10") // maybe 2.7
     public data class Language(
         @SerialName("code")
         val code: String? = null,

--- a/mirai-core-api/src/commonMain/kotlin/event/MessageSubscribersBuilder.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/MessageSubscribersBuilder.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.event.events.*
 import net.mamoe.mirai.internal.event.*
 import net.mamoe.mirai.message.data.*
 import net.mamoe.mirai.message.data.MessageSource.Key.quote
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import kotlin.annotation.AnnotationTarget.CONSTRUCTOR
 
 
@@ -273,6 +274,7 @@ public open class MessageSubscribersBuilder<M : MessageEvent, out Ret, R : RR, R
     /** 如果是群临时会话消息 */
     @MessageDsl
     @Deprecated("use sentByGroupTemp()", ReplaceWith("sentByGroupTemp()"), DeprecationLevel.HIDDEN)
+    @DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
     public fun sentByTemp(): ListeningFilter = sentByGroupTemp()
 
     /** 如果是群临时会话消息 */

--- a/mirai-core-api/src/commonMain/kotlin/event/events/MessageEvent.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/events/MessageEvent.kt
@@ -22,6 +22,7 @@ import net.mamoe.mirai.message.data.MessageSource
 import net.mamoe.mirai.message.data.OnlineMessageSource
 import net.mamoe.mirai.message.data.source
 import net.mamoe.mirai.message.isContextIdenticalWith
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiInternalApi
 
 
@@ -195,6 +196,7 @@ public class GroupMessageEvent(
     replaceWith = ReplaceWith("GroupTempMessageEvent", "net.mamoe.mirai.event.events.GroupTempMessageEvent"),
     DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
 public sealed class TempMessageEvent constructor(
     public override val sender: NormalMember,
     public override val message: MessageChain,

--- a/mirai-core-api/src/commonMain/kotlin/event/events/MessagePostSendEvent.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/events/MessagePostSendEvent.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.internal.event.VerboseEvent
 import net.mamoe.mirai.message.MessageReceipt
 import net.mamoe.mirai.message.data.MessageChain
 import net.mamoe.mirai.message.data.MessageSource
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiInternalApi
 
 
@@ -156,6 +157,7 @@ public data class FriendMessagePostSendEvent @MiraiInternalApi constructor(
     ),
     DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
 public sealed class TempMessagePostSendEvent @MiraiInternalApi constructor(
     /** 发信目标. */
     public override val target: Member,

--- a/mirai-core-api/src/commonMain/kotlin/event/events/MessagePreSendEvent.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/events/MessagePreSendEvent.kt
@@ -18,6 +18,7 @@ import net.mamoe.mirai.event.AbstractEvent
 import net.mamoe.mirai.event.CancellableEvent
 import net.mamoe.mirai.internal.event.VerboseEvent
 import net.mamoe.mirai.message.data.Message
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiInternalApi
 
 
@@ -85,6 +86,7 @@ public data class FriendMessagePreSendEvent @MiraiInternalApi constructor(
     ),
     DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
 public sealed class TempMessagePreSendEvent @MiraiInternalApi constructor(
     /** 发信目标. */
     public override val target: Member,

--- a/mirai-core-api/src/commonMain/kotlin/event/subscribeMessages.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/subscribeMessages.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.contact.User
 import net.mamoe.mirai.event.ConcurrencyKind.CONCURRENT
 import net.mamoe.mirai.event.events.*
 import net.mamoe.mirai.message.data.content
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.coroutines.CoroutineContext
@@ -151,6 +152,7 @@ public fun <R> EventChannel<*>.subscribeUserMessages(
     ),
     DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
 public typealias TempMessageSubscribersBuilder = MessageSubscribersBuilder<GroupTempMessageEvent, Listener<GroupTempMessageEvent>, Unit, Unit>
 
 /**
@@ -167,6 +169,7 @@ public typealias TempMessageSubscribersBuilder = MessageSubscribersBuilder<Group
     ),
     DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(hiddenSince = "2.0") // maybe 2.0
 public fun <R> EventChannel<*>.subscribeTempMessages(
     coroutineContext: CoroutineContext = EmptyCoroutineContext,
     concurrencyKind: ConcurrencyKind = CONCURRENT,

--- a/mirai-core-api/src/commonMain/kotlin/internal/message/MessageSerializersImpl.kt
+++ b/mirai-core-api/src/commonMain/kotlin/internal/message/MessageSerializersImpl.kt
@@ -119,7 +119,7 @@ private val builtInSerializersModule by lazy {
             subclass(SimpleServiceMessage::class, SimpleServiceMessage.serializer())
 
             //  subclass(PttMessage::class, PttMessage.serializer())
-            @Suppress("DEPRECATION")
+            @Suppress("DEPRECATION_ERROR")
             subclass(Voice::class, Voice.serializer())
 
             // subclass(HummerMessage::class, HummerMessage.serializer())

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Deprecated.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Deprecated.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.mamoe.mirai.IMirai
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.safeCast
 
 
@@ -37,6 +38,7 @@ import net.mamoe.mirai.utils.safeCast
     ),
     level = DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.6", hiddenSince = "2.8")
 public class RichMessageOrigin
 @Deprecated(
     "Use MessageOrigin instead.",
@@ -46,6 +48,7 @@ public class RichMessageOrigin
     ),
     level = DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.6", hiddenSince = "2.8")
 constructor(
     /**
      * 原 [RichMessage].
@@ -106,6 +109,7 @@ constructor(
         ),
         level = DeprecationLevel.HIDDEN
     )
+    @DeprecatedSinceMirai(errorSince = "2.6", hiddenSince = "2.8")
     @Suppress("DEPRECATION_ERROR")
     public companion object Key : AbstractMessageKey<RichMessageOrigin>({ it.safeCast() }) {
         public const val SERIAL_NAME: String = "RichMessageOrigin"
@@ -122,6 +126,7 @@ constructor(
     ReplaceWith("MessageOriginKind", "net.mamoe.mirai.message.data.MessageOriginKind"),
     level = DeprecationLevel.HIDDEN
 )
+@DeprecatedSinceMirai(errorSince = "2.6", hiddenSince = "2.8")
 public enum class RichMessageKind {
     /**
      * 长消息

--- a/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
@@ -80,6 +80,7 @@ public interface FileMessage : MessageContent, ConstrainSingle, CodableMessage {
      */
     @Suppress("DEPRECATION")
     @Deprecated("Please use toAbsoluteFile", ReplaceWith("this.toAbsoluteFile(contact)")) // deprecated since 2.8.0-RC
+    @DeprecatedSinceMirai(warningSince = "2.8")
     public suspend fun toRemoteFile(contact: FileSupported): RemoteFile? {
         @Suppress("DEPRECATION")
         return contact.filesRoot.resolveById(id)

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -405,6 +405,7 @@ public enum class ImageType(
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
 @MiraiInternalApi
 @get:JvmName("calculateImageMd5")
+@DeprecatedSinceMirai(hiddenSince = "2.9")
 public val Image.md5: ByteArray
     get() = Image.calculateImageMd5ByImageId(imageId)
 

--- a/mirai-core-api/src/commonMain/kotlin/message/data/MessageChain.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/MessageChain.kt
@@ -33,6 +33,7 @@ import net.mamoe.mirai.message.data.MessageChain.Companion.serializeToJsonString
 import net.mamoe.mirai.message.data.MessageSource.Key.quote
 import net.mamoe.mirai.message.data.MessageSource.Key.recall
 import net.mamoe.mirai.message.data.MessageSource.Key.recallIn
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 import net.mamoe.mirai.utils.NotStableForInheritance
 import net.mamoe.mirai.utils.safeCast
@@ -366,6 +367,7 @@ public object EmptyMessageChain : MessageChain, List<SingleMessage> by emptyList
                 "Please specify your serial property as MessageChain and use contextual and polymorphic serializers from MessageSerializers.serializersModule.",
         level = DeprecationLevel.WARNING
     ) // deprecated since 2.8-M1
+    @DeprecatedSinceMirai(warningSince = "2.8")
     public fun serializer(): KSerializer<MessageChain> = MessageChain.Serializer
 
     private object EmptyMessageChainIterator : Iterator<SingleMessage> {

--- a/mirai-core-api/src/commonMain/kotlin/message/data/SingleMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/SingleMessage.kt
@@ -19,6 +19,7 @@ package net.mamoe.mirai.message.data
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.PolymorphicSerializer
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.safeCast
 
 /**
@@ -37,8 +38,9 @@ public interface SingleMessage : Message {
             "kotlinx.serialization.PolymorphicSerializer",
             "net.mamoe.mirai.message.data.SingleMessage",
         ),
-        level = DeprecationLevel.ERROR // ERROR since 2.8
+        level = DeprecationLevel.HIDDEN // ERROR since 2.8
     ) // error since 2.8
+    @DeprecatedSinceMirai(warningSince = "2.4", errorSince = "2.8", hiddenSince = "2.10")
     public object Serializer : KSerializer<SingleMessage> by PolymorphicSerializer(SingleMessage::class)
 }
 

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Voice.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Voice.kt
@@ -17,10 +17,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import net.mamoe.mirai.contact.Group
-import net.mamoe.mirai.utils.MiraiExperimentalApi
-import net.mamoe.mirai.utils.MiraiInternalApi
-import net.mamoe.mirai.utils.NotStableForInheritance
-import net.mamoe.mirai.utils.safeCast
+import net.mamoe.mirai.utils.*
 
 
 /**
@@ -66,14 +63,15 @@ public abstract class PttMessage : MessageContent {
  * - 将 [Group.uploadVoice] 替换为 [Group.uploadAudio]
  * - 如果有必须使用旧 [Voice] 类型的情况, 请使用 [Audio.toVoice]
  */
-@Suppress("DuplicatedCode", "DEPRECATION")
+@Suppress("DuplicatedCode", "DEPRECATION", "DEPRECATION_ERROR")
 @Serializable
 @SerialName(Voice.SERIAL_NAME)
 @Deprecated(
     "Please use Audio instead.",
     replaceWith = ReplaceWith("Audio", "net.mamoe.mirai.message.data.Audio"),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 ) // deprecated since 2.7
+@DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
 public open class Voice @MiraiInternalApi constructor(
     @MiraiExperimentalApi public override val fileName: String,
     @MiraiExperimentalApi public override val md5: ByteArray,
@@ -83,6 +81,12 @@ public open class Voice @MiraiInternalApi constructor(
     private val _url: String
 ) : PttMessage() {
 
+    @Deprecated(
+        "Please use Audio instead.",
+        replaceWith = ReplaceWith("Audio.Key", "net.mamoe.mirai.message.data.Audio.Key"),
+        level = DeprecationLevel.ERROR
+    ) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public companion object Key : AbstractPolymorphicMessageKey<PttMessage, Voice>(PttMessage, { it.safeCast() }) {
         public const val SERIAL_NAME: String = "Voice"
 
@@ -95,8 +99,9 @@ public open class Voice @MiraiInternalApi constructor(
         @Suppress("DeprecatedCallableAddReplaceWith")
         @Deprecated(
             "Please consider migrating to Audio",
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         @JvmStatic
         public fun fromAudio(audio: Audio): Voice {
             audio.run {
@@ -175,10 +180,11 @@ public open class Voice @MiraiInternalApi constructor(
  *
  * @since 2.7
  */
-@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith")
+@Suppress("DEPRECATION", "DeprecatedCallableAddReplaceWith", "DEPRECATION_ERROR")
 @Deprecated(
     "Please migrate to Audio",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 ) // deprecated since 2.7
 @JvmSynthetic
+@DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
 public inline fun Audio.toVoice(): Voice = Voice.fromAudio(this)

--- a/mirai-core-api/src/commonMain/kotlin/network/ForceOfflineException.kt
+++ b/mirai-core-api/src/commonMain/kotlin/network/ForceOfflineException.kt
@@ -12,11 +12,13 @@ package net.mamoe.mirai.network
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import net.mamoe.mirai.Bot
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 
 /**
  * 当 [Bot] 被迫下线时抛出, 作为 [Job.cancel] 的 `cause`
  */
-@Deprecated("Not used anymore since 2.7", level = DeprecationLevel.ERROR) // deprecated since 2.7, error since 2.8
+@Deprecated("Not used anymore since 2.7", level = DeprecationLevel.HIDDEN) // deprecated since 2.7, error since 2.8
+@DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.8", hiddenSince = "2.10")
 public class ForceOfflineException
 @JvmOverloads constructor(
     public override val message: String? = null,

--- a/mirai-core-api/src/commonMain/kotlin/utils/BotConfiguration.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/BotConfiguration.kt
@@ -198,15 +198,17 @@ public open class BotConfiguration { // open for Java
     /** 心跳失败后的第一次重连前的等待时间. */
     @Deprecated(
         "Useless since new network. Please just remove this.",
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     ) // deprecated since 2.7, error since 2.8
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.8", hiddenSince = "2.10")
     public var firstReconnectDelayMillis: Long = 5.secondsToMillis
 
     /** 重连失败后, 继续尝试的每次等待时间 */
     @Deprecated(
         "Useless since new network. Please just remove this.",
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     ) // deprecated since 2.7, error since 2.8
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.8", hiddenSince = "2.10")
     public var reconnectPeriodMillis: Long = 5.secondsToMillis
 
     /** 最多尝试多少次重连 */
@@ -585,10 +587,6 @@ public open class BotConfiguration { // open for Java
             new.heartbeatTimeoutMillis = heartbeatTimeoutMillis
             new.statHeartbeatPeriodMillis = statHeartbeatPeriodMillis
             new.heartbeatStrategy = heartbeatStrategy
-            @Suppress("DEPRECATION")
-            new.firstReconnectDelayMillis = firstReconnectDelayMillis
-            @Suppress("DEPRECATION")
-            new.reconnectPeriodMillis = reconnectPeriodMillis
             new.reconnectionRetryTimes = reconnectionRetryTimes
             new.autoReconnectOnForceOffline = autoReconnectOnForceOffline
             new.loginSolver = loginSolver

--- a/mirai-core-api/src/commonMain/kotlin/utils/ExternalResource.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/ExternalResource.kt
@@ -225,25 +225,6 @@ public interface ExternalResource : Closeable {
         public fun InputStream.toExternalResource(formatName: String? = null): ExternalResource =
             Mirai.FileCacheStrategy.newCache(this, formatName)
 
-
-        /* note:
-        于 2.8.0-M1 添加 (#1392)
-
-        于 2.8.0-RC 移动至 `toExternalResource`(#1588)
-
-        Fixme: 在 2.8.0 标为 HIDDEN
-         */
-        @JvmName("createAutoCloseable")
-        @JvmStatic
-        @Deprecated(
-            level = DeprecationLevel.ERROR,
-            message = "Moved to `toExternalResource()`",
-            replaceWith = ReplaceWith("resource.toAutoCloseable()"),
-        )
-        public fun createAutoCloseable(resource: ExternalResource): ExternalResource {
-            return resource.toAutoCloseable()
-        }
-
         // endregion
 
         ///////////////////////////////////////////////////////////////////////////
@@ -368,7 +349,7 @@ public interface ExternalResource : Closeable {
          * @see RemoteFile.path
          * @see RemoteFile.upload
          */
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION","DEPRECATION_ERROR")
         @JvmStatic
         @JvmBlockingBridge
         @JvmOverloads
@@ -378,8 +359,9 @@ public interface ExternalResource : Closeable {
                 "this.sendTo(contact, path, callback)",
                 "net.mamoe.mirai.utils.ExternalResource.Companion.sendTo"
             ),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7-M1
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public suspend fun File.uploadTo(
             contact: FileSupported,
             path: String,
@@ -403,7 +385,7 @@ public interface ExternalResource : Closeable {
          * @see RemoteFile.path
          * @see RemoteFile.upload
          */
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         @JvmStatic
         @JvmBlockingBridge
         @JvmName("uploadAsFile")
@@ -414,8 +396,9 @@ public interface ExternalResource : Closeable {
                 "this.sendAsFileTo(contact, path, callback)",
                 "net.mamoe.mirai.utils.ExternalResource.Companion.sendAsFileTo"
             ),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7-M1
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public suspend fun ExternalResource.uploadAsFile(
             contact: FileSupported,
             path: String,
@@ -440,7 +423,7 @@ public interface ExternalResource : Closeable {
          * @see RemoteFile.path
          * @see RemoteFile.uploadAndSend
          */
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION_ERROR", "DEPRECATION")
         @Deprecated(
             "Deprecated. Please use AbsoluteFolder.uploadNewFile",
             ReplaceWith("contact.files.uploadNewFile(path, this, callback)")
@@ -448,6 +431,7 @@ public interface ExternalResource : Closeable {
         @JvmStatic
         @JvmBlockingBridge
         @JvmOverloads
+        @DeprecatedSinceMirai(warningSince = "2.8")
         public suspend fun <C : FileSupported> File.sendTo(
             contact: C,
             path: String,
@@ -466,7 +450,7 @@ public interface ExternalResource : Closeable {
          * @see RemoteFile.path
          * @see RemoteFile.uploadAndSend
          */
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         @Deprecated(
             "Deprecated. Please use AbsoluteFolder.uploadNewFile",
             ReplaceWith("contact.files.uploadNewFile(path, this, callback)")
@@ -475,6 +459,7 @@ public interface ExternalResource : Closeable {
         @JvmBlockingBridge
         @JvmName("sendAsFile")
         @JvmOverloads
+        @DeprecatedSinceMirai(warningSince = "2.8")
         public suspend fun <C : FileSupported> ExternalResource.sendAsFileTo(
             contact: C,
             path: String,
@@ -489,13 +474,14 @@ public interface ExternalResource : Closeable {
         // region uploadAsVoice
         ///////////////////////////////////////////////////////////////////////////
 
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION", "DEPRECATION_ERROR")
         @JvmBlockingBridge
         @JvmStatic
         @Deprecated(
             "Use `contact.uploadAudio(resource)` instead",
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public suspend fun ExternalResource.uploadAsVoice(contact: Contact): net.mamoe.mirai.message.data.Voice {
             @Suppress("DEPRECATION")
             if (contact is Group) return contact.uploadVoice(this)

--- a/mirai-core-api/src/commonMain/kotlin/utils/MiraiLogger.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/MiraiLogger.kt
@@ -94,7 +94,8 @@ public interface MiraiLogger {
          */
         @MiraiInternalApi
         @MiraiExperimentalApi
-        @Deprecated("Deprecated.") // deprecated since 2.7
+        @Deprecated("Deprecated.", level = DeprecationLevel.ERROR) // deprecated since 2.7
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public val TopLevel: MiraiLogger by lazy { Factory.create(MiraiLogger::class, "Mirai") }
 
         /**
@@ -103,9 +104,10 @@ public interface MiraiLogger {
         @Suppress("DeprecatedCallableAddReplaceWith")
         @Deprecated(
             "Please set factory by providing an service of type net.mamoe.mirai.utils.MiraiLogger.Factory",
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7
         @JvmStatic
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public fun setDefaultLoggerCreator(creator: (identity: String?) -> MiraiLogger) {
             DefaultFactoryOverrides.override { _, identity -> creator(identity) }
         }
@@ -119,9 +121,10 @@ public interface MiraiLogger {
             "Please use MiraiLogger.Factory.create", ReplaceWith(
                 "MiraiLogger.Factory.create(YourClass::class, identity)",
                 "net.mamoe.mirai.utils.MiraiLogger"
-            ), level = DeprecationLevel.WARNING
+            ), level = DeprecationLevel.ERROR
         ) // deprecated since 2.7
         @JvmStatic
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public fun create(identity: String?): MiraiLogger = Factory.create(MiraiLogger::class, identity)
     }
 
@@ -208,7 +211,8 @@ public interface MiraiLogger {
      * 当然, 多个 logger 也可以加在一起: `val logger = bot.logger + MynLogger() + MyLogger2()`
      */
     @Suppress("UNUSED_PARAMETER")
-    @Deprecated("follower 设计不佳, 请避免使用", level = DeprecationLevel.WARNING) // deprecated since 2.7
+    @Deprecated("follower 设计不佳, 请避免使用", level = DeprecationLevel.ERROR) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public var follower: MiraiLogger?
         get() = null
         set(value) {}
@@ -274,7 +278,8 @@ public interface MiraiLogger {
      * @return [follower]
      */
     @Suppress("DeprecatedCallableAddReplaceWith")
-    @Deprecated("plus 设计不佳, 请避免使用.", level = DeprecationLevel.WARNING) // deprecated since 2.7
+    @Deprecated("plus 设计不佳, 请避免使用.", level = DeprecationLevel.ERROR) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public operator fun <T : MiraiLogger> plus(follower: T): T = follower
 }
 
@@ -464,12 +469,13 @@ public class MiraiLoggerWithSwitch internal constructor(private val delegate: Mi
  * @see PlatformLogger
  * @see SimpleLogger
  */
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION_ERROR")
 public abstract class MiraiLoggerPlatformBase : MiraiLogger {
     public override val isEnabled: Boolean get() = true
 
     @Suppress("OverridingDeprecatedMember")
-    @Deprecated("follower 设计不佳, 请避免使用", level = DeprecationLevel.WARNING) // deprecated since 2.7
+    @Deprecated("follower 设计不佳, 请避免使用", level = DeprecationLevel.ERROR) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public final override var follower: MiraiLogger? = null
 
     public final override fun verbose(message: String?) {
@@ -544,7 +550,8 @@ public abstract class MiraiLoggerPlatformBase : MiraiLogger {
     protected abstract fun error0(message: String?, e: Throwable?)
 
     @Suppress("OverridingDeprecatedMember")
-    @Deprecated("plus 设计不佳, 请避免使用.", level = DeprecationLevel.WARNING) // deprecated since 2.7
+    @Deprecated("plus 设计不佳, 请避免使用.", level = DeprecationLevel.ERROR) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public override operator fun <T : MiraiLogger> plus(follower: T): T {
         this.follower = follower
         return follower

--- a/mirai-core-api/src/commonMain/kotlin/utils/RemoteFile.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/RemoteFile.kt
@@ -97,7 +97,8 @@ import java.io.File
  * @see FileSupported
  * @since 2.5
  */
-@Deprecated("Please use RemoteFiles and AbsoluteFileFolder form fileSupported.files") // deprecated since 2.8.0-RC
+@Deprecated("Please use RemoteFiles and AbsoluteFileFolder form fileSupported.files", level = DeprecationLevel.WARNING) // deprecated since 2.8.0-RC
+@DeprecatedSinceMirai(warningSince = "2.8")
 @NotStableForInheritance
 public interface RemoteFile {
     /**
@@ -300,8 +301,9 @@ public interface RemoteFile {
     @Deprecated(
         "Use moveTo(RemoteFile) instead.",
         replaceWith = ReplaceWith("this.moveTo(this.resolveSibling(path))"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     ) // deprecated since 2.7
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun moveTo(path: String): Boolean {
         // Impl notes:
         // if `path` is absolute, this works as intended.
@@ -351,8 +353,10 @@ public interface RemoteFile {
      */
     @Deprecated(
         "Deprecated without replacement. Please use AbsoluteFolder.uploadNewFile",
-        ReplaceWith("contact.files.uploadNewFile(path, this, callback)")
+        ReplaceWith("contact.files.uploadNewFile(path, this, callback)"),
+        level = DeprecationLevel.WARNING
     ) // deprecated since 2.8.0-RC
+    @DeprecatedSinceMirai(warningSince = "2.8")
     public interface ProgressionCallback {
         /**
          * 当上传开始时调用
@@ -452,8 +456,9 @@ public interface RemoteFile {
      * @throws IllegalStateException 该文件上传失败或权限不足时抛出
      */
     @Deprecated(
-        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(resource, callback)"), DeprecationLevel.WARNING
+        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(resource, callback)"), DeprecationLevel.ERROR
     ) // deprecated since 2.7-M1
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun upload(
         resource: ExternalResource,
         callback: ProgressionCallback? = null,
@@ -465,10 +470,11 @@ public interface RemoteFile {
      * 阅读 [upload] 获取更多信息
      * @see upload
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Deprecated(
-        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(resource)"), DeprecationLevel.WARNING
+        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(resource)"), DeprecationLevel.ERROR
     )  // deprecated since 2.7-M1
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun upload(resource: ExternalResource): FileMessage = upload(resource, null)
 
     /**
@@ -477,10 +483,11 @@ public interface RemoteFile {
      * 阅读 [upload] 获取更多信息
      * @see upload
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Deprecated(
-        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(file, callback)"), DeprecationLevel.WARNING
+        "Use uploadAndSend instead.", ReplaceWith("this.uploadAndSend(file, callback)"), DeprecationLevel.ERROR
     ) // deprecated since 2.7-M1
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun upload(
         file: File,
         callback: ProgressionCallback? = null,
@@ -492,10 +499,11 @@ public interface RemoteFile {
      * 阅读 [upload] 获取更多信息
      * @see upload
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Deprecated(
-        "Use sendFile instead.", ReplaceWith("this.uploadAndSend(file)"), DeprecationLevel.WARNING
+        "Use sendFile instead.", ReplaceWith("this.uploadAndSend(file)"), DeprecationLevel.ERROR
     ) // deprecated since 2.7-M1
+    @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
     public suspend fun upload(file: File): FileMessage = file.toExternalResource().use { upload(it) }
 
     /**
@@ -576,13 +584,14 @@ public interface RemoteFile {
                 "this.sendFile(path, resource, callback)",
                 "net.mamoe.mirai.utils.RemoteFile.Companion.sendFile"
             ),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7-M1
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public suspend fun FileSupported.uploadFile(
             path: String,
             resource: ExternalResource,
             callback: ProgressionCallback? = null,
-        ): FileMessage = @Suppress("DEPRECATION") this.filesRoot.resolve(path).upload(resource, callback)
+        ): FileMessage = @Suppress("DEPRECATION", "DEPRECATION_ERROR") this.filesRoot.resolve(path).upload(resource, callback)
 
         /**
          * 上传文件并获取文件消息, 但不发送.
@@ -600,13 +609,14 @@ public interface RemoteFile {
                 "this.sendFile(path, file, callback)",
                 "net.mamoe.mirai.utils.RemoteFile.Companion.sendFile"
             ),
-            level = DeprecationLevel.WARNING
+            level = DeprecationLevel.ERROR
         ) // deprecated since 2.7-M1
+        @DeprecatedSinceMirai(warningSince = "2.7", errorSince = "2.10")
         public suspend fun FileSupported.uploadFile(
             path: String,
             file: File,
             callback: ProgressionCallback? = null,
-        ): FileMessage = @Suppress("DEPRECATION") this.filesRoot.resolve(path).upload(file, callback)
+        ): FileMessage = @Suppress("DEPRECATION", "DEPRECATION_ERROR") this.filesRoot.resolve(path).upload(file, callback)
 
         /**
          * 上传文件并发送文件消息到相关 [FileSupported].
@@ -620,12 +630,13 @@ public interface RemoteFile {
             ReplaceWith("this.files.uploadNewFile(path, resource, callback)"),
             level = DeprecationLevel.WARNING
         ) // deprecated since 2.8.0-RC
+        @DeprecatedSinceMirai(warningSince = "2.8")
         public suspend fun <C : FileSupported> C.sendFile(
             path: String,
             resource: ExternalResource,
             callback: ProgressionCallback? = null,
         ): MessageReceipt<C> =
-            @Suppress("DEPRECATION")
+            @Suppress("DEPRECATION", "DEPRECATION_ERROR")
             this.filesRoot.resolve(path).upload(resource, callback).sendTo(this)
 
         /**
@@ -639,12 +650,13 @@ public interface RemoteFile {
             ReplaceWith("file.toExternalResource().use { this.files.uploadNewFile(path, it, callback) }"),
             level = DeprecationLevel.WARNING
         ) // deprecated since 2.8.0-RC
+        @DeprecatedSinceMirai(warningSince = "2.8")
         public suspend fun <C : FileSupported> C.sendFile(
             path: String,
             file: File,
             callback: ProgressionCallback? = null,
         ): MessageReceipt<C> =
-            @Suppress("DEPRECATION")
+            @Suppress("DEPRECATION", "DEPRECATION_ERROR")
             this.filesRoot.resolve(path).upload(file, callback).sendTo(this)
     }
 }

--- a/mirai-core-api/src/commonTest/kotlin/logging/LoggingCompatibilityTest.kt
+++ b/mirai-core-api/src/commonTest/kotlin/logging/LoggingCompatibilityTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertIs
 
 internal class LoggingCompatibilityTest {
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Test
     fun `legacy overrides are still working if no services are found`() {
         val messages = StringBuilder()

--- a/mirai-core-api/src/commonTest/kotlin/utils/TimeTest.kt
+++ b/mirai-core-api/src/commonTest/kotlin/utils/TimeTest.kt
@@ -15,24 +15,8 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
 
 internal class TimeTest {
-    @Suppress("DEPRECATION_ERROR")
-    @ExperimentalTime
-    @Test
-    fun testTimeHumanReadable() {
-        val time0 = 1.toDuration(DurationUnit.DAYS) +
-                20.toDuration(DurationUnit.HOURS) +
-                15.toDuration(DurationUnit.MINUTES) +
-                2057.toDuration(DurationUnit.MILLISECONDS)
-        println(time0.toHumanReadableString())
-        assertTrue { time0.toHumanReadableString() == "1d 20h 15min 2.057s" }
-        val time1 = 1.toDuration(DurationUnit.DAYS) + 59.toDuration(DurationUnit.MINUTES)
-        println(time1.toHumanReadableString())
-        assertTrue { time1.toHumanReadableString() == "1d 59min 0.0s" }
-    }
-
     // since 2.7
     @OptIn(ExperimentalTime::class)
-    @Suppress("DEPRECATION_ERROR")
     @Test
     fun testTimeHumanReadable2() {
         val time0 = (1.toDuration(DurationUnit.DAYS) +

--- a/mirai-core-utils/src/commonMain/kotlin/Annotations.kt
+++ b/mirai-core-utils/src/commonMain/kotlin/Annotations.kt
@@ -18,8 +18,22 @@ import kotlin.annotation.AnnotationTarget.*
 public annotation class TestOnly
 
 /**
+ * 标注 API 弃用记录, 用于在将来提升弃用等级.
+ *
+ * 注意, 在使用时必须使用 named arguments, 如:
+ * ```
+ * @DeprecatedSinceMirai(warningSince = "2.9")
+ * ```
+ *
  * @since 2.9.0-RC
  */ // https://github.com/mamoe/mirai/issues/1669
+@Target(
+    CLASS,
+    PROPERTY,
+    CONSTRUCTOR,
+    FUNCTION,
+    TYPEALIAS
+)
 public annotation class DeprecatedSinceMirai(
     val warningSince: String = "",
     val errorSince: String = "",

--- a/mirai-core-utils/src/commonMain/kotlin/TimeUtils.kt
+++ b/mirai-core-utils/src/commonMain/kotlin/TimeUtils.kt
@@ -83,8 +83,9 @@ public inline val Int.monthsToSeconds: Long
     get() = this * 30.daysToSeconds
 
 // @MiraiExperimentalApi
-@Deprecated("Do not use unstable API", level = DeprecationLevel.ERROR)
+@Deprecated("Do not use unstable API", level = DeprecationLevel.HIDDEN)
 @ExperimentalTime
+@DeprecatedSinceMirai(errorSince = "2.7", hiddenSince = "2.10") // maybe 2.7
 public fun Duration.toHumanReadableString(): String {
     val days = toInt(DurationUnit.DAYS)
     val hours = toInt(DurationUnit.HOURS) % 24

--- a/mirai-core/src/commonMain/kotlin/BotFactory.kt
+++ b/mirai-core/src/commonMain/kotlin/BotFactory.kt
@@ -16,6 +16,7 @@ package net.mamoe.mirai.internal
 import net.mamoe.mirai.Bot
 import net.mamoe.mirai.BotFactory
 import net.mamoe.mirai.utils.BotConfiguration
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 
 /**
  * QQ for Android
@@ -23,8 +24,9 @@ import net.mamoe.mirai.utils.BotConfiguration
 @Deprecated(
     "BotFactoryImpl was accidentally made public, use BotFactory.INSTANCE instead",
     ReplaceWith("BotFactory", "net.mamoe.mirai.BotFactory"),
-    DeprecationLevel.WARNING,
+    DeprecationLevel.ERROR,
 )
+@DeprecatedSinceMirai(errorSince = "2.10")
 public object BotFactoryImpl : BotFactory {
 
     /**

--- a/mirai-core/src/commonMain/kotlin/MiraiImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/MiraiImpl.kt
@@ -139,7 +139,7 @@ internal open class MiraiImpl : IMirai, LowLevelApiAccessor {
         }
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     override val BotFactory: BotFactory
         get() = BotFactoryImpl
 

--- a/mirai-core/src/commonMain/kotlin/contact/GroupImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/contact/GroupImpl.kt
@@ -111,7 +111,8 @@ internal class GroupImpl constructor(
     override lateinit var botAsMember: NormalMemberImpl
 
     @Suppress("DEPRECATION")
-    @Deprecated("Please use files instead.", replaceWith = ReplaceWith("files.root"))
+    @Deprecated("Please use files instead.", replaceWith = ReplaceWith("files.root"), level = DeprecationLevel.WARNING)
+    @DeprecatedSinceMirai(warningSince = "2.8")
     override val filesRoot: RemoteFile by lazy { RemoteFileImpl(this, "/") }
     override val files: RemoteFiles by lazy { RemoteFilesImpl(this) }
 

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/PacketFactory.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/PacketFactory.kt
@@ -27,6 +27,7 @@ import net.mamoe.mirai.internal.network.protocol.packet.login.Heartbeat
 import net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc
 import net.mamoe.mirai.internal.network.protocol.packet.login.WtLogin
 import net.mamoe.mirai.internal.network.protocol.packet.summarycard.SummaryCard
+import net.mamoe.mirai.utils.DeprecatedSinceMirai
 import net.mamoe.mirai.utils.MiraiLoggerWithSwitch
 
 internal sealed class PacketFactory<TPacket : Packet?> {
@@ -117,6 +118,7 @@ internal suspend inline fun <P : Packet?> IncomingPacketFactory<P>.decode(
     level = DeprecationLevel.HIDDEN,
 )
 @PublishedApi
+@DeprecatedSinceMirai(hiddenSince = "2.7")
 internal val PacketLogger: MiraiLoggerWithSwitch
     get() = PacketCodec.PacketLogger
 

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/MessageSvc.PbSendMsg.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/MessageSvc.PbSendMsg.kt
@@ -162,7 +162,7 @@ internal object MessageSvcPbSendMsg : OutgoingPacketFactory<MessageSvcPbSendMsg.
             fileType = 4,
             pbReserve = byteArrayOf(0),
             format = let {
-                @Suppress("DEPRECATION")
+                @Suppress("DEPRECATION_ERROR")
                 if (it is Voice) {
                     it._codec
                 } else {

--- a/mirai-core/src/commonMain/kotlin/utils/RemoteFileImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/utils/RemoteFileImpl.kt
@@ -548,15 +548,18 @@ internal class RemoteFileImpl(
     }
 
     // compiler bug
+    @Suppress("DEPRECATION_ERROR")
     override suspend fun upload(resource: ExternalResource): FileMessage {
         return upload(resource, null)
     }
 
     // compiler bug
+    @Suppress("DEPRECATION_ERROR")
     override suspend fun upload(file: File, callback: RemoteFile.ProgressionCallback?): FileMessage =
         file.toExternalResource().use { upload(it, callback) }
 
     //compiler bug
+    @Suppress("DEPRECATION_ERROR")
     override suspend fun upload(file: File): FileMessage {
         // Dear compiler:
         //

--- a/mirai-core/src/commonTest/kotlin/test/initPlatform.common.kt
+++ b/mirai-core/src/commonTest/kotlin/test/initPlatform.common.kt
@@ -39,7 +39,7 @@ abstract class AbstractTest {
 
     @AfterEach
     protected fun restoreLoggerFactory() {
-        @Suppress("DEPRECATION")
+        @Suppress("DEPRECATION_ERROR")
         MiraiLogger.setDefaultLoggerCreator {
             SynchronizedStdoutLogger(it)
         }


### PR DESCRIPTION
重要: 
- 删除了 `createAutoCloseable`, 因为它在 2.8.0-M1 加入时就标注了 `@MiraiExperiemntalApi`, 在 2.8.0-RC 弃用