### PR TITLE
fix: Plugin Dependency Requirement check

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/plugin/PluginManagerImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/PluginManagerImpl.kt
@@ -257,7 +257,7 @@ internal fun List<PluginDescription>.findDependency(dependency: PluginDependency
 
 internal fun PluginDescription.checkSatisfies(dependency: PluginDependency, plugin: PluginDescription) {
     val requirement = dependency.versionRequirement ?: return
-    if (SemVersion.parseRangeRequirement(requirement).test(this.version)) {
+    if (!SemVersion.parseRangeRequirement(requirement).test(this.version)) {
         throw PluginLoadException("Plugin '${plugin.id}' ('${plugin.id}') requires '${dependency.id}' with version $requirement while the resolved is ${this.version}")
     }
 }


### PR DESCRIPTION
依赖版本检查应该 在**不**符合条件时 抛出异常