### PR TITLE
add: ImageType.JPEG

### DIFF
--- a/mirai-core-api/compatibility-validation/android/api/android.api
+++ b/mirai-core-api/compatibility-validation/android/api/android.api
@@ -4539,11 +4539,11 @@ public final class net/mamoe/mirai/message/data/ImageType : java/lang/Enum {
 	public static final field BMP Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field Companion Lnet/mamoe/mirai/message/data/ImageType$Companion;
 	public static final field GIF Lnet/mamoe/mirai/message/data/ImageType;
-	public static final field JPEG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field JPG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field PNG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field UNKNOWN Lnet/mamoe/mirai/message/data/ImageType;
 	public final fun getFormatName ()Ljava/lang/String;
+	public final fun getSecondaryNames ()[Ljava/lang/String;
 	public static final fun match (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;
 	public static final fun matchOrNull (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;
 	public static fun valueOf (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;

--- a/mirai-core-api/compatibility-validation/android/api/android.api
+++ b/mirai-core-api/compatibility-validation/android/api/android.api
@@ -4539,6 +4539,7 @@ public final class net/mamoe/mirai/message/data/ImageType : java/lang/Enum {
 	public static final field BMP Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field Companion Lnet/mamoe/mirai/message/data/ImageType$Companion;
 	public static final field GIF Lnet/mamoe/mirai/message/data/ImageType;
+	public static final field JPEG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field JPG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field PNG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field UNKNOWN Lnet/mamoe/mirai/message/data/ImageType;

--- a/mirai-core-api/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-core-api/compatibility-validation/jvm/api/jvm.api
@@ -4539,11 +4539,11 @@ public final class net/mamoe/mirai/message/data/ImageType : java/lang/Enum {
 	public static final field BMP Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field Companion Lnet/mamoe/mirai/message/data/ImageType$Companion;
 	public static final field GIF Lnet/mamoe/mirai/message/data/ImageType;
-	public static final field JPEG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field JPG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field PNG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field UNKNOWN Lnet/mamoe/mirai/message/data/ImageType;
 	public final fun getFormatName ()Ljava/lang/String;
+	public final fun getSecondaryNames ()[Ljava/lang/String;
 	public static final fun match (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;
 	public static final fun matchOrNull (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;
 	public static fun valueOf (Ljava/lang/String;)Lnet/mamoe/mirai/message/data/ImageType;

--- a/mirai-core-api/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-core-api/compatibility-validation/jvm/api/jvm.api
@@ -4539,6 +4539,7 @@ public final class net/mamoe/mirai/message/data/ImageType : java/lang/Enum {
 	public static final field BMP Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field Companion Lnet/mamoe/mirai/message/data/ImageType$Companion;
 	public static final field GIF Lnet/mamoe/mirai/message/data/ImageType;
+	public static final field JPEG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field JPG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field PNG Lnet/mamoe/mirai/message/data/ImageType;
 	public static final field UNKNOWN Lnet/mamoe/mirai/message/data/ImageType;

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -378,6 +378,7 @@ public enum class ImageType(
     GIF("gif"),
     //WEBP, //Unsupported by pc client
     APNG("png"),
+    JPEG("jpg"),
     UNKNOWN("gif"); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
 
     public companion object {

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -371,14 +371,14 @@ public enum class ImageType(
      * @since 2.9.0
      */
     @MiraiInternalApi public val formatName: String,
+    @MiraiInternalApi public vararg val secondaryNames: String
 ) {
     PNG("png"),
     BMP("bmp"),
-    JPG("jpg"),
+    JPG("jpg", "jpeg", "jpe"),
     GIF("gif"),
     //WEBP, //Unsupported by pc client
     APNG("png"),
-    JPEG("jpg"),
     UNKNOWN("gif"); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
 
     public companion object {
@@ -392,7 +392,7 @@ public enum class ImageType(
         @JvmStatic
         public fun matchOrNull(str: String): ImageType? {
             val input = str.uppercase()
-            return IMAGE_TYPE_ENUM_LIST.firstOrNull { it.name == input }
+            return IMAGE_TYPE_ENUM_LIST.firstOrNull { it.name == input || it.secondaryNames.contains(input) }
         }
     }
 }

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -375,7 +375,7 @@ public enum class ImageType(
 ) {
     PNG("png"),
     BMP("bmp"),
-    JPG("jpg", "jpeg", "jpe"),
+    JPG("jpg", "JPEG", "JPE"),
     GIF("gif"),
     //WEBP, //Unsupported by pc client
     APNG("png"),

--- a/mirai-core/src/commonMain/kotlin/message/ImageDecoder.kt
+++ b/mirai-core/src/commonMain/kotlin/message/ImageDecoder.kt
@@ -152,7 +152,7 @@ internal fun ExternalResource.calculateImageInfo(): ImageInfo {
     val imageType = ImageType.match(formatName)
     return inputStream().asInput().withUse {
         when (imageType) {
-            ImageType.JPG -> getJPGImageInfo()
+            ImageType.JPG, ImageType.JPEG -> getJPGImageInfo()
             ImageType.BMP -> getBMPImageInfo()
             ImageType.GIF -> getGIFImageInfo()
             ImageType.PNG, ImageType.APNG -> getPNGImageInfo()

--- a/mirai-core/src/commonMain/kotlin/message/ImageDecoder.kt
+++ b/mirai-core/src/commonMain/kotlin/message/ImageDecoder.kt
@@ -152,7 +152,7 @@ internal fun ExternalResource.calculateImageInfo(): ImageInfo {
     val imageType = ImageType.match(formatName)
     return inputStream().asInput().withUse {
         when (imageType) {
-            ImageType.JPG, ImageType.JPEG -> getJPGImageInfo()
+            ImageType.JPG -> getJPGImageInfo()
             ImageType.BMP -> getBMPImageInfo()
             ImageType.GIF -> getGIFImageInfo()
             ImageType.PNG, ImageType.APNG -> getPNGImageInfo()


### PR DESCRIPTION
有些时候文件的后缀命名是 jpeg，还有就是 http header 中  jpg 图片 的 Content-Type 一般是 image/jpeg，
这里是希望，对于 `jpeg` 不用处理直接 可以作为 `formatName` 参数