### PR TITLE
Add: OtherClientCommandSenderOnMessageSync

### DIFF
--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -377,6 +377,7 @@ public abstract interface class net/mamoe/mirai/console/command/CommandSender : 
 	public static fun from (Lnet/mamoe/mirai/event/events/GroupMessageEvent;)Lnet/mamoe/mirai/console/command/MemberCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/GroupTempMessageEvent;)Lnet/mamoe/mirai/console/command/GroupTempCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/MessageEvent;)Lnet/mamoe/mirai/console/command/CommandSenderOnMessage;
+	public static fun from (Lnet/mamoe/mirai/event/events/MessageSyncEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync;
 	public static fun from (Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/StrangerMessageEvent;)Lnet/mamoe/mirai/console/command/StrangerCommandSenderOnMessage;
 	public abstract fun getBot ()Lnet/mamoe/mirai/Bot;
@@ -401,6 +402,7 @@ public final class net/mamoe/mirai/console/command/CommandSender$Companion {
 	public final fun from (Lnet/mamoe/mirai/event/events/GroupMessageEvent;)Lnet/mamoe/mirai/console/command/MemberCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/GroupTempMessageEvent;)Lnet/mamoe/mirai/console/command/GroupTempCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/MessageEvent;)Lnet/mamoe/mirai/console/command/CommandSenderOnMessage;
+	public final fun from (Lnet/mamoe/mirai/event/events/MessageSyncEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync;
 	public final fun from (Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/StrangerMessageEvent;)Lnet/mamoe/mirai/console/command/StrangerCommandSenderOnMessage;
 	public final fun of (Lnet/mamoe/mirai/contact/Friend;)Lnet/mamoe/mirai/console/command/FriendCommandSender;
@@ -599,6 +601,11 @@ public class net/mamoe/mirai/console/command/OtherClientCommandSender : net/mamo
 public final class net/mamoe/mirai/console/command/OtherClientCommandSenderOnMessage : net/mamoe/mirai/console/command/OtherClientCommandSender, net/mamoe/mirai/console/command/CommandSenderOnMessage {
 	public synthetic fun getFromEvent ()Lnet/mamoe/mirai/event/events/MessageEvent;
 	public fun getFromEvent ()Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;
+}
+
+public final class net/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync : net/mamoe/mirai/console/command/OtherClientCommandSender, net/mamoe/mirai/console/command/CommandSenderOnMessage {
+	public synthetic fun getFromEvent ()Lnet/mamoe/mirai/event/events/MessageEvent;
+	public fun getFromEvent ()Lnet/mamoe/mirai/event/events/MessageSyncEvent;
 }
 
 public abstract class net/mamoe/mirai/console/command/RawCommand : net/mamoe/mirai/console/command/Command {

--- a/mirai-console/backend/mirai-console/src/command/CommandSender.kt
+++ b/mirai-console/backend/mirai-console/src/command/CommandSender.kt
@@ -51,9 +51,9 @@ import kotlin.coroutines.CoroutineContext
  * - [MessageEvent.toCommandSender]
  * - [FriendMessageEvent.toCommandSender]
  * - [GroupMessageEvent.toCommandSender]
- * - [TempMessageEvent.toCommandSender]
  * - [StrangerMessageEvent.toCommandSender]
  * - [OtherClientMessageEvent.toCommandSender]
+ * - [MessageSyncEvent.toCommandSender]
  *
  * - [Member.asCommandSender]
  * - [NormalMember.asTempCommandSender]
@@ -227,6 +227,14 @@ public interface CommandSender : CoroutineScope, Permittee {
             OtherClientCommandSenderOnMessage(this)
 
         /**
+         * 构造 [OtherClientCommandSenderOnMessageSync]
+         */
+        @JvmStatic
+        @JvmName("from")
+        public fun MessageSyncEvent.toCommandSender(): OtherClientCommandSenderOnMessageSync =
+            OtherClientCommandSenderOnMessageSync(this)
+
+        /**
          * 构造 [CommandSenderOnMessage]
          */
         @JvmStatic
@@ -238,6 +246,7 @@ public interface CommandSender : CoroutineScope, Permittee {
             is GroupTempMessageEvent -> toCommandSender()
             is StrangerMessageEvent -> toCommandSender()
             is OtherClientMessageEvent -> toCommandSender()
+            is MessageSyncEvent -> toCommandSender()
             else -> throw IllegalArgumentException("Unsupported MessageEvent: ${this::class.qualifiedNameOrTip}")
         } as CommandSenderOnMessage<T>
 
@@ -737,3 +746,11 @@ public class StrangerCommandSenderOnMessage internal constructor(
 public class OtherClientCommandSenderOnMessage internal constructor(
     public override val fromEvent: OtherClientMessageEvent,
 ) : OtherClientCommandSender(fromEvent.client), CommandSenderOnMessage<OtherClientMessageEvent>
+
+/**
+ * 代表一个 [其他客户端][OtherClient] 主动在群内、好友聊天等发送消息执行指令
+ * @see OtherClientCommandSender 代表一个 [其他客户端][OtherClient] 执行指令, 但不一定是通过私聊方式
+ */
+public class OtherClientCommandSenderOnMessageSync internal constructor(
+    public override val fromEvent: MessageSyncEvent,
+) : OtherClientCommandSender(fromEvent.client), CommandSenderOnMessage<MessageSyncEvent>

--- a/mirai-core-api/compatibility-validation/android/api/android.api
+++ b/mirai-core-api/compatibility-validation/android/api/android.api
@@ -2374,8 +2374,9 @@ public final class net/mamoe/mirai/event/events/FriendMessagePreSendEvent : net/
 }
 
 public final class net/mamoe/mirai/event/events/FriendMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/FriendEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Friend;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Friend;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getFriend ()Lnet/mamoe/mirai/contact/Friend;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Friend;
@@ -2556,8 +2557,9 @@ public final class net/mamoe/mirai/event/events/GroupMessagePreSendEvent : net/m
 }
 
 public final class net/mamoe/mirai/event/events/GroupMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/GroupAwareMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Group;Lnet/mamoe/mirai/message/data/MessageChain;Lnet/mamoe/mirai/contact/Member;Ljava/lang/String;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Group;Lnet/mamoe/mirai/message/data/MessageChain;Lnet/mamoe/mirai/contact/Member;Ljava/lang/String;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getGroup ()Lnet/mamoe/mirai/contact/Group;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Member;
@@ -2688,8 +2690,9 @@ public final class net/mamoe/mirai/event/events/GroupTempMessagePreSendEvent : n
 }
 
 public final class net/mamoe/mirai/event/events/GroupTempMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/GroupAwareMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/NormalMember;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/NormalMember;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getGroup ()Lnet/mamoe/mirai/contact/Group;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/NormalMember;
@@ -3038,6 +3041,7 @@ public final class net/mamoe/mirai/event/events/MessageRecallEvent$GroupRecall :
 }
 
 public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent {
+	public abstract fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 }
 
 public final class net/mamoe/mirai/event/events/NewFriendRequestEvent : net/mamoe/mirai/event/AbstractEvent, net/mamoe/mirai/event/events/BotEvent, net/mamoe/mirai/event/events/FriendInfoChangeEvent, net/mamoe/mirai/internal/network/Packet {
@@ -3196,8 +3200,9 @@ public final class net/mamoe/mirai/event/events/StrangerMessagePreSendEvent : ne
 }
 
 public final class net/mamoe/mirai/event/events/StrangerMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent, net/mamoe/mirai/event/events/StrangerEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Stranger;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Stranger;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Stranger;
 	public synthetic fun getSender ()Lnet/mamoe/mirai/contact/User;

--- a/mirai-core-api/compatibility-validation/android/api/android.api
+++ b/mirai-core-api/compatibility-validation/android/api/android.api
@@ -3040,7 +3040,8 @@ public final class net/mamoe/mirai/event/events/MessageRecallEvent$GroupRecall :
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent {
+public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent, net/mamoe/mirai/event/events/OtherClientEvent {
+	public fun getBot ()Lnet/mamoe/mirai/Bot;
 	public abstract fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 }
 

--- a/mirai-core-api/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-core-api/compatibility-validation/jvm/api/jvm.api
@@ -2374,8 +2374,9 @@ public final class net/mamoe/mirai/event/events/FriendMessagePreSendEvent : net/
 }
 
 public final class net/mamoe/mirai/event/events/FriendMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/FriendEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Friend;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Friend;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getFriend ()Lnet/mamoe/mirai/contact/Friend;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Friend;
@@ -2556,8 +2557,9 @@ public final class net/mamoe/mirai/event/events/GroupMessagePreSendEvent : net/m
 }
 
 public final class net/mamoe/mirai/event/events/GroupMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/GroupAwareMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Group;Lnet/mamoe/mirai/message/data/MessageChain;Lnet/mamoe/mirai/contact/Member;Ljava/lang/String;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Group;Lnet/mamoe/mirai/message/data/MessageChain;Lnet/mamoe/mirai/contact/Member;Ljava/lang/String;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getGroup ()Lnet/mamoe/mirai/contact/Group;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Member;
@@ -2688,8 +2690,9 @@ public final class net/mamoe/mirai/event/events/GroupTempMessagePreSendEvent : n
 }
 
 public final class net/mamoe/mirai/event/events/GroupTempMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/GroupAwareMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/NormalMember;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/NormalMember;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getGroup ()Lnet/mamoe/mirai/contact/Group;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/NormalMember;
@@ -3038,6 +3041,7 @@ public final class net/mamoe/mirai/event/events/MessageRecallEvent$GroupRecall :
 }
 
 public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent {
+	public abstract fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 }
 
 public final class net/mamoe/mirai/event/events/NewFriendRequestEvent : net/mamoe/mirai/event/AbstractEvent, net/mamoe/mirai/event/events/BotEvent, net/mamoe/mirai/event/events/FriendInfoChangeEvent, net/mamoe/mirai/internal/network/Packet {
@@ -3196,8 +3200,9 @@ public final class net/mamoe/mirai/event/events/StrangerMessagePreSendEvent : ne
 }
 
 public final class net/mamoe/mirai/event/events/StrangerMessageSyncEvent : net/mamoe/mirai/event/events/AbstractMessageEvent, net/mamoe/mirai/event/events/MessageSyncEvent, net/mamoe/mirai/event/events/StrangerEvent {
-	public fun <init> (Lnet/mamoe/mirai/contact/Stranger;Lnet/mamoe/mirai/message/data/MessageChain;I)V
+	public fun <init> (Lnet/mamoe/mirai/contact/OtherClient;Lnet/mamoe/mirai/contact/Stranger;Lnet/mamoe/mirai/message/data/MessageChain;I)V
 	public fun getBot ()Lnet/mamoe/mirai/Bot;
+	public fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 	public fun getMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public fun getSender ()Lnet/mamoe/mirai/contact/Stranger;
 	public synthetic fun getSender ()Lnet/mamoe/mirai/contact/User;

--- a/mirai-core-api/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-core-api/compatibility-validation/jvm/api/jvm.api
@@ -3040,7 +3040,8 @@ public final class net/mamoe/mirai/event/events/MessageRecallEvent$GroupRecall :
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent {
+public abstract interface class net/mamoe/mirai/event/events/MessageSyncEvent : net/mamoe/mirai/event/events/MessageEvent, net/mamoe/mirai/event/events/OtherClientEvent {
+	public fun getBot ()Lnet/mamoe/mirai/Bot;
 	public abstract fun getClient ()Lnet/mamoe/mirai/contact/OtherClient;
 }
 

--- a/mirai-core-api/src/commonMain/kotlin/event/events/MessageSyncEvent.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/events/MessageSyncEvent.kt
@@ -27,8 +27,9 @@ import net.mamoe.mirai.message.data.source
  *
  * @see MessageEvent
  */
-public interface MessageSyncEvent : MessageEvent {
-    public val client: OtherClient
+public interface MessageSyncEvent : MessageEvent, OtherClientEvent {
+    public override val client: OtherClient
+    override val bot: Bot get() = client.bot
 }
 
 /**
@@ -47,7 +48,7 @@ public class GroupTempMessageSyncEvent(
         check(source is OnlineMessageSource.Incoming.FromTemp) { "source provided to a GroupTempMessageSyncEvent must be an instance of OnlineMessageSource.Incoming.FromTemp" }
     }
 
-    public override val bot: Bot get() = sender.bot
+    public override val bot: Bot get() = client.bot
     public override val subject: NormalMember get() = sender
     public override val group: Group get() = sender.group
     public override val senderName: String get() = sender.nameCardOrNick
@@ -72,7 +73,7 @@ public class FriendMessageSyncEvent constructor(
     }
 
     public override val friend: Friend get() = sender
-    public override val bot: Bot get() = super.bot
+    public override val bot: Bot get() = client.bot
     public override val subject: Friend get() = sender
     public override val senderName: String get() = sender.nick
     public override val source: OnlineMessageSource.Incoming.FromFriend get() = message.source as OnlineMessageSource.Incoming.FromFriend
@@ -96,7 +97,7 @@ public class StrangerMessageSyncEvent constructor(
     }
 
     public override val stranger: Stranger get() = sender
-    public override val bot: Bot get() = super.bot
+    public override val bot: Bot get() = client.bot
     public override val subject: Stranger get() = sender
     public override val senderName: String get() = sender.nick
     public override val source: OnlineMessageSource.Incoming.FromStranger get() = message.source as OnlineMessageSource.Incoming.FromStranger
@@ -120,7 +121,7 @@ public class GroupMessageSyncEvent(
         check(source is OnlineMessageSource.Incoming.FromGroup) { "source provided to a GroupMessageSyncEvent must be an instance of OnlineMessageSource.Incoming.FromGroup" }
     }
 
-    override val bot: Bot get() = group.bot
+    override val bot: Bot get() = client.bot
     override val subject: Group get() = group
     override val source: OnlineMessageSource.Incoming.FromGroup get() = message.source as OnlineMessageSource.Incoming.FromGroup
 

--- a/mirai-core-api/src/commonMain/kotlin/event/events/MessageSyncEvent.kt
+++ b/mirai-core-api/src/commonMain/kotlin/event/events/MessageSyncEvent.kt
@@ -27,7 +27,9 @@ import net.mamoe.mirai.message.data.source
  *
  * @see MessageEvent
  */
-public interface MessageSyncEvent : MessageEvent
+public interface MessageSyncEvent : MessageEvent {
+    public val client: OtherClient
+}
 
 /**
  * 机器人在其他客户端发送群临时会话消息同步到这个客户端的事件
@@ -35,6 +37,7 @@ public interface MessageSyncEvent : MessageEvent
  * @see MessageSyncEvent
  */
 public class GroupTempMessageSyncEvent(
+    public override val client: OtherClient,
     public override val sender: NormalMember,
     public override val message: MessageChain,
     public override val time: Int
@@ -57,6 +60,7 @@ public class GroupTempMessageSyncEvent(
  * @see MessageSyncEvent
  */
 public class FriendMessageSyncEvent constructor(
+    public override val client: OtherClient,
     public override val sender: Friend,
     public override val message: MessageChain,
     public override val time: Int
@@ -80,6 +84,7 @@ public class FriendMessageSyncEvent constructor(
  * @see MessageSyncEvent
  */
 public class StrangerMessageSyncEvent constructor(
+    public override val client: OtherClient,
     public override val sender: Stranger,
     public override val message: MessageChain,
     public override val time: Int
@@ -103,11 +108,12 @@ public class StrangerMessageSyncEvent constructor(
  * @see MessageSyncEvent
  */
 public class GroupMessageSyncEvent(
-    override val group: Group,
-    override val message: MessageChain,
-    override val sender: Member,
-    override val senderName: String,
-    override val time: Int
+    public override val client: OtherClient,
+    public override val group: Group,
+    public override val message: MessageChain,
+    public override val sender: Member,
+    public override val senderName: String,
+    public override val time: Int
 ) : AbstractMessageEvent(), GroupAwareMessageEvent, MessageSyncEvent {
     init {
         val source = message[MessageSource] ?: error("Cannot find MessageSource from message")

--- a/mirai-core/src/commonMain/kotlin/network/notice/group/GroupMessageProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/group/GroupMessageProcessor.kt
@@ -18,11 +18,8 @@ import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.event.events.GroupMessageSyncEvent
 import net.mamoe.mirai.event.events.MemberCardChangeEvent
 import net.mamoe.mirai.event.events.MemberSpecialTitleChangeEvent
-import net.mamoe.mirai.internal.contact.GroupImpl
-import net.mamoe.mirai.internal.contact.NormalMemberImpl
-import net.mamoe.mirai.internal.contact.info
+import net.mamoe.mirai.internal.contact.*
 import net.mamoe.mirai.internal.contact.info.MemberInfoImpl
-import net.mamoe.mirai.internal.contact.newAnonymous
 import net.mamoe.mirai.internal.message.toMessageChainOnline
 import net.mamoe.mirai.internal.network.Packet
 import net.mamoe.mirai.internal.network.components.NoticePipelineContext
@@ -139,6 +136,8 @@ internal class GroupMessageProcessor(
         if (isFromSelfAccount) {
             collect(
                 GroupMessageSyncEvent(
+                    client = bot.otherClients.find { it.appId == msgHead.fromInstid }
+                        ?: return, // don't compare with dstAppId. diff.
                     message = msgs.map { it.msg }.toMessageChainOnline(bot, group.id, MessageSourceKind.GROUP),
                     time = msgHead.msgTime,
                     group = group,

--- a/mirai-core/src/commonMain/kotlin/network/notice/priv/PrivateMessageProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/priv/PrivateMessageProcessor.kt
@@ -130,10 +130,12 @@ internal class PrivateMessageProcessor : SimpleNoticeProcessor<MsgComm.Msg>(type
         val time = msgHead.msgTime
 
         collected += if (fromSync) {
+            val client = bot.otherClients.find { it.appId == msgHead.fromInstid }
+                ?: return // don't compare with dstAppId. diff.
             when (user) {
-                is FriendImpl -> FriendMessageSyncEvent(user, chain, time)
-                is StrangerImpl -> StrangerMessageSyncEvent(user, chain, time)
-                is NormalMemberImpl -> GroupTempMessageSyncEvent(user, chain, time)
+                is FriendImpl -> FriendMessageSyncEvent(client, user, chain, time)
+                is StrangerImpl -> StrangerMessageSyncEvent(client, user, chain, time)
+                is NormalMemberImpl -> GroupTempMessageSyncEvent(client, user, chain, time)
                 is AnonymousMemberImpl -> assertUnreachable()
             }
         } else {


### PR DESCRIPTION
想法是把 `MessageSyncEvent` 对接到 `OtherClientCommandSender` ,
但是 `MessageSyncEvent` 好像没有 `client` 方法（属性），所以改了 `MessageSyncEvent` 的 继承及实现

参考 OtherClientNoticeProcessor 改的代码，不过 return 而不是 throw 或者 给个 `UnknownClient` 真的好吗，信息直接被丢弃了

https://github.com/mamoe/mirai/blob/3a2663104b3b18eff88c83f4ab8a9b7335830209/mirai-core/src/commonMain/kotlin/network/notice/priv/OtherClientNoticeProcessor.kt#L124-L125