### PR TITLE
fix: cancel error info

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
+++ b/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
@@ -41,7 +41,7 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
         } else {
             grantedPermissionsMap[permission.id].remove(permitteeId)
         }
-        check(success) {
+        if (!success) {
             val about = buildList {
                 for ((permissionIdentifier, permissibleIdentifiers) in grantedPermissionsMap) {
                     val parent = get(permissionIdentifier) ?: continue
@@ -53,7 +53,7 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
                     }
                 }
             }
-            if (about.isEmpty()) {
+            val message = if (about.isEmpty()) {
                 "${permitteeId.asString()} 不拥有权限 ${permission.id} "
             } else {
                 buildString {
@@ -64,6 +64,8 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
                     appendLine("Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.")
                 }
             }
+
+            throw UnsupportedOperationException(message)
         }
     }
 

--- a/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
+++ b/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
@@ -12,6 +12,7 @@ package net.mamoe.mirai.console.internal.permission
 import net.mamoe.mirai.console.data.PluginDataExtensions
 import net.mamoe.mirai.console.permission.*
 import net.mamoe.mirai.console.permission.Permission.Companion.parentsWithSelf
+import net.mamoe.mirai.console.permission.PermitteeId.Companion.allParentsWithSelf
 import net.mamoe.mirai.console.permission.PermitteeId.Companion.hasChild
 
 internal abstract class AbstractConcurrentPermissionService<P : Permission> : PermissionService<P> {
@@ -47,14 +48,14 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
                     val parent = get(permissionIdentifier) ?: continue
                     if (parent !in permission.parentsWithSelf) continue
                     for (permissibleId in permissibleIdentifiers) {
-                        if (permissibleId.hasChild(permitteeId)) {
+                        if (permissibleId in permitteeId.allParentsWithSelf) {
                             add(parent to permissibleId)
                         }
                     }
                 }
             }
             val message = if (about.isEmpty()) {
-                "${permitteeId.asString()} 不拥有权限 ${permission.id} "
+                "${permitteeId.asString()} 不拥有权限 ${permission.id}"
             } else {
                 buildString {
                     appendLine("${permitteeId.asString()} 的 ${permission.id} 权限来自")

--- a/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
+++ b/mirai-console/backend/mirai-console/src/internal/permission/AbstractConcurrentPermissionService.kt
@@ -47,7 +47,7 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
                     val parent = get(permissionIdentifier) ?: continue
                     if (parent !in permission.parentsWithSelf) continue
                     for (permissibleId in permissibleIdentifiers) {
-                        if (permitteeId.hasChild(permitteeId)) {
+                        if (permissibleId.hasChild(permitteeId)) {
                             add(parent to permissibleId)
                         }
                     }
@@ -56,11 +56,13 @@ internal abstract class AbstractConcurrentPermissionService<P : Permission> : Pe
             if (about.isEmpty()) {
                 "${permitteeId.asString()} 不拥有权限 ${permission.id} "
             } else {
-                """
-                    ${permitteeId.asString()} 的 ${permission.id} 权限来自
-                    ${about.joinToString("\n") { (parent, permitted) -> "${permitted.asString()} ${parent.id}" }}
-                    Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.
-                """.trimIndent()
+                buildString {
+                    appendLine("${permitteeId.asString()} 的 ${permission.id} 权限来自")
+                    about.forEach { (parent, permitted) ->
+                        appendLine("${permitted.asString()} ${parent.id}")
+                    }
+                    appendLine("Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.")
+                }
             }
         }
     }

--- a/mirai-console/backend/mirai-console/test/permission/PermissionServiceTest.kt
+++ b/mirai-console/backend/mirai-console/test/permission/PermissionServiceTest.kt
@@ -42,12 +42,12 @@ internal class PermissionServiceTest {
         // test cancel fail (by parent)
         val cause1 = assertFails { builtIn.cancel(member, command, false) }
         assertTrue { cause1 is UnsupportedOperationException }
-        assertTrue { """
+        assertEquals("""
             m12345.6789 的 plugin:command 权限来自
             m12345.* plugin:*
             Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.
             
-        """.trimIndent() == cause1.message }
+        """.trimIndent(), cause1.message)
 
         // test recursive cancel
         builtIn.cancel(any, builtIn.rootPermission, true)
@@ -59,7 +59,7 @@ internal class PermissionServiceTest {
         // test cancel (no permit)
         val cause2 = assertFails { builtIn.cancel(member, command, false) }
         assertTrue { cause2 is UnsupportedOperationException }
-        assertTrue { "${member.asString()} 不拥有权限 ${command.id}" == cause2.message }
+        assertEquals("${member.asString()} 不拥有权限 ${command.id}", cause2.message)
 
         // test not recursive cancel
         builtIn.permit(any, plugin)

--- a/mirai-console/backend/mirai-console/test/permission/PermissionServiceTest.kt
+++ b/mirai-console/backend/mirai-console/test/permission/PermissionServiceTest.kt
@@ -39,7 +39,15 @@ internal class PermissionServiceTest {
         assertTrue { builtIn.testPermission(any, command) }
         assertTrue { builtIn.testPermission(member, command) }
 
-        assertFails { builtIn.cancel(member, command, false) }
+        // test cancel fail (by parent)
+        val cause1 = assertFails { builtIn.cancel(member, command, false) }
+        assertTrue { cause1 is UnsupportedOperationException }
+        assertTrue { """
+            m12345.6789 的 plugin:command 权限来自
+            m12345.* plugin:*
+            Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.
+            
+        """.trimIndent() == cause1.message }
 
         // test recursive cancel
         builtIn.cancel(any, builtIn.rootPermission, true)
@@ -47,6 +55,11 @@ internal class PermissionServiceTest {
         assertFalse { builtIn.testPermission(member, plugin) }
         assertFalse { builtIn.testPermission(any, command) }
         assertFalse { builtIn.testPermission(member, command) }
+
+        // test cancel (no permit)
+        val cause2 = assertFails { builtIn.cancel(member, command, false) }
+        assertTrue { cause2 is UnsupportedOperationException }
+        assertTrue { "${member.asString()} 不拥有权限 ${command.id}" == cause2.message }
 
         // test not recursive cancel
         builtIn.permit(any, plugin)
@@ -56,7 +69,5 @@ internal class PermissionServiceTest {
         assertFalse { builtIn.testPermission(member, plugin) }
         assertTrue { builtIn.testPermission(any, command) }
         assertTrue { builtIn.testPermission(member, command) }
-
-        assertFails { builtIn.cancel(member, command, false) }
     }
 }


### PR DESCRIPTION
修正撤回权限失败时的错误信息


![QQ图片20220309113727](https://user-images.githubusercontent.com/32539286/157368056-0c36bf95-8adf-4bb6-9234-8e9318907397.gif)

```
> /permission cancel * xyz.cssxsh.mirai.plugin.bilibili-helper:*
2022-03-09 10:50:56 E/console: java.lang.reflect.InvocationTargetException
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)
        at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Instance.call(CallerImpl.kt:113)
        at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108)
        at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:159)
        at kotlin.reflect.full.KCallables.callSuspendBy(KCallables.kt:74)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invokeSuspend(CommandReflector.kt:305)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invoke(CommandReflector.kt)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invoke(CommandReflector.kt)
        at net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunctionImpl.call$suspendImpl(CommandSignature.kt:88)
        at net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunctionImpl.call(CommandSignature.kt)
        at net.mamoe.mirai.console.internal.command.CommandManagerImplKt.executeCommandImpl(CommandManagerImpl.kt:167)
        at net.mamoe.mirai.console.command.CommandManager.executeCommand(CommandManager.kt:131)
        at net.mamoe.mirai.console.command.CommandManager$INSTANCE.executeCommand(CommandManager.kt)
        at net.mamoe.mirai.console.terminal.ConsoleThreadKt$startupConsoleThread$3.invokeSuspend(ConsoleThread.kt:191)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
Caused by: java.lang.IllegalStateException:                     * 的 xyz.cssxsh.mirai.plugin.bilibili-helper:* 权限来自
                    console *:*
u123456 *:*
u* xyz.cssxsh.mirai.plugin.bilibili-helper:*
                    Mirai Console 内置权限系统目前不支持单独禁用继承得到的权限. 可取消继承来源再为其分别分配.
        at net.mamoe.mirai.console.internal.permission.AbstractConcurrentPermissionService.cancel(AbstractConcurrentPermissionService.kt:44)
        at net.mamoe.mirai.console.permission.PermissionService$Companion.cancel0(PermissionService.kt:209)
        at net.mamoe.mirai.console.command.BuiltInCommands$PermissionCommand.cancel(BuiltInCommands.kt:270)
        ... 24 more
```