### PR TITLE
fix doc

### DIFF
--- a/docs/UsingSnapshots.md
+++ b/docs/UsingSnapshots.md
@@ -67,7 +67,7 @@ dependencies {
 settings.gradle(.kts)
 ```
 pluginManagement {
-    dependencies {
+    repositories {
         gradlePluginPortal()
         maven("https://repo.mirai.mamoe.net/snapshots")
     }


### PR DESCRIPTION
[Gradle 文档](https://docs.gradle.org/6.8/userguide/plugins.html#sec:custom_plugin_repositories)

否则
> Could not find method dependencies() for arguments …… on object of type org.gradle.plugin.management.internal.DefaultPluginManagementSpec