### PR TITLE
fix: MarketFace contentToString

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/message/data/MarketFace.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/MarketFace.kt
@@ -35,7 +35,7 @@ public interface MarketFace : HummerMessage {
 
     override val key: MessageKey<MarketFace> get() = Key
 
-    override fun contentToString(): String = name
+    override fun contentToString(): String = name.ifEmpty { "[商城表情]" }
 
     public companion object Key :
         AbstractPolymorphicMessageKey<HummerMessage, MarketFace>(HummerMessage, { it.safeCast() }) {


### PR DESCRIPTION
收到的 `MarketFace.name`  有一定几率是空的，无法通过 isContentEmpty 检查
https://github.com/mamoe/mirai/blob/0d3bc9c6842961a12f89c17a7e2cc4d6a83616a6/mirai-core-api/src/commonMain/kotlin/message/data/Message.kt#L305-L310