### PR TITLE
fix: FileMessage.Delegate SerialName

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
@@ -113,7 +113,7 @@ public interface FileMessage : MessageContent, ConstrainSingle, CodableMessage {
             Mirai.createFileMessage(id, internalId, name, size)
     }
 
-    public object Serializer : KSerializer<FileMessage> by FallbackSerializer("FileMessage") // not polymorphic
+    public object Serializer : KSerializer<FileMessage> by FallbackSerializer(SERIAL_NAME) // not polymorphic
 
     @MiraiInternalApi
     private open class FallbackSerializer(serialName: String) : KSerializer<FileMessage> by Delegate.serializer().map(
@@ -121,7 +121,7 @@ public interface FileMessage : MessageContent, ConstrainSingle, CodableMessage {
         serialize = { Delegate(id, internalId, name, size) },
         deserialize = { Mirai.createFileMessage(id, internalId, name, size) },
     ) {
-        @SerialName(Image.SERIAL_NAME)
+        @SerialName(SERIAL_NAME)
         @Serializable
         data class Delegate(
             val id: String,


### PR DESCRIPTION
FileMessage 错误地使用了 Image.SERIAL_NAME

https://github.com/mamoe/mirai/blob/d8ceb7ae5b7bb0528e403f5ad8331e7f7d95c03d/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt#L116-L132