### PR TITLE
修复在插件配置的路径中使用子路径出现的异常

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
@@ -62,7 +62,10 @@ internal open class MultiFilePluginDataStorageImpl(
             error("Target File $file is occupied by a directory therefore data ${instance::class.qualifiedNameOrTip} can't be saved.")
         }
 //        logger.verbose { "File allocated for ${instance.saveName}: $file" }
-        return file.toFile().also { it.createNewFile() }
+        return file.toFile().also {
+            it.parentFile?.mkdirs()
+            it.createNewFile()
+        }
     }
 
     @ConsoleExperimentalApi

--- a/mirai-console/docs/PluginData.md
+++ b/mirai-console/docs/PluginData.md
@@ -110,7 +110,7 @@ object MyData : AutoSavePluginData("MyData") { // 文件名为 MyData, 会被保
 
 3. 建立自动保存链接
 使用 `PluginDataStorage.load(PluginDataHolder, PluginData)` 即可完成自动保存链接，并读取数据。  
-对于 [JVM 插件][`JvmPlugin`]，可简便地在 `onEnable()` 中使用 `MyData.reload()`（对于上例）。详见 [读取 `PluginData` 或 `PluginConfig`](Plugins.md#读取-plugindata-或-pluginconfig)
+对于 [JVM 插件][`JvmPlugin`]，可简便地在 `onEnable()` 中使用 `MyData.reload()`（对于上例）。详见 [读取 `PluginData` 或 `PluginConfig`](plugin/JVMPlugin-Appendix.md#读取-plugindata-或-pluginconfig)
 
 ### 定义数据模型（Java）
 *由于 Java 语法局限，为 Kotlin 而设计的 PluginData 在 Java 使用很复杂。*  


### PR DESCRIPTION
如题，在 `AutoSavePluginData` 的构造函数参数 `saveName` 中填入 `group/xxx`，会出现如下异常
```
java.io.IOException: 系统找不到指定的路径。
	at java.base/java.io.WinNTFileSystem.createFileExclusively(Native Method)
	at java.base/java.io.File.createNewFile(File.java:1035)
	at net.mamoe.mirai.console.internal.data.MultiFilePluginDataStorageImpl.getPluginDataFile(MultiFilePluginDataStorageImpl.kt:65)
	at net.mamoe.mirai.console.internal.data.MultiFilePluginDataStorageImpl.load(MultiFilePluginDataStorageImpl.kt:38)
	at top.mrxiaom.TestPlugin.loadData(TestPlugin.kt:28)
	…
```