### PR TITLE
在 MultiFilePluginDataStorage.load 失败时，备份数据文件

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
@@ -43,7 +43,7 @@ internal open class MultiFilePluginDataStorageImpl(
                 yaml.decodeFromString(instance.updaterSerializer, text)
             } catch (cause: Throwable) {
                 // backup data file
-                file.copyTo(file.resolveSibling("$file.bak"))
+                file.copyTo(file.resolveSibling("${file.name}.bak"))
                 throw cause
             }
         } else {

--- a/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/data/MultiFilePluginDataStorageImpl.kt
@@ -18,6 +18,7 @@ import net.mamoe.mirai.console.data.PluginDataStorage
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
 import net.mamoe.mirai.message.MessageSerializers
 import net.mamoe.mirai.utils.MiraiLogger
+import net.mamoe.mirai.utils.currentTimeMillis
 import net.mamoe.yamlkt.Yaml
 import java.io.File
 import java.nio.file.Path
@@ -43,7 +44,7 @@ internal open class MultiFilePluginDataStorageImpl(
                 yaml.decodeFromString(instance.updaterSerializer, text)
             } catch (cause: Throwable) {
                 // backup data file
-                file.copyTo(file.resolveSibling("${file.name}.bak"))
+                file.copyTo(file.resolveSibling("${file.name}.${currentTimeMillis()}.bak"))
                 throw cause
             }
         } else {


### PR DESCRIPTION
如果 数据文件出错，比如 手动编辑 `AutoLogin.yaml` 配置 时错误，或者序列化失败等其他错误
数据文件将会因为定时保存和关闭时的强制保存，被默认配置覆盖