### PR TITLE
native: 优化 build script 及 actions，修复 ECDH 相关资源释放问题

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           - windows-2022
           - macos-12
     env:
-      gradleArgs: --scan "-Dmirai.target=jvm;android;!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
+      gradleArgs: --scan "-Dmirai.target=jvm;android;!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8"
       isMac: ${{ startsWith(matrix.os, 'macos') }}
       isWindows: ${{ startsWith(matrix.os, 'windows') }}
       isUbuntu: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -314,12 +314,12 @@ jobs:
     env:
       # FIXME there must be two or more targets, or we'll get error on `@OptionalExpectation`
       # > Declaration annotated with '@OptionalExpectation' can only be used in common module sources
-      gradleArgs: --scan  "-Dmirai.target=jvm;${{ matrix.targetName }};!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
+      gradleArgs: --scan  "-Dmirai.target=jvm;${{ matrix.targetName }};!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8"
       isMac: ${{ startsWith(matrix.os, 'macos') }}
       isWindows: ${{ startsWith(matrix.os, 'windows') }}
       isUbuntu: ${{ startsWith(matrix.os, 'ubuntu') }}
       isUnix: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ startsWith(matrix.os, 'windows') && 'C:\\vcpkg\\binary_cache' || '/usr/local/share/vcpkg/binary_cache' }}
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ startsWith(matrix.os, 'windows') && 'C:\vcpkg\binary_cache' || '/usr/local/share/vcpkg/binary_cache' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           - windows-2022
           - macos-12
     env:
-      gradleArgs: --scan "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
+      gradleArgs: --scan "-Dmirai.target=jvm;android;!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
       isMac: ${{ startsWith(matrix.os, 'macos') }}
       isWindows: ${{ startsWith(matrix.os, 'windows') }}
       isUbuntu: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -34,6 +34,13 @@ jobs:
       - if: ${{ env.isUnix == 'true' }}
         run: chmod -R 777 *
 
+      - if: ${{ env.isWindows == 'true' }}
+        name: Setup Memory Environment on Windows
+        run: >
+          wmic pagefileset where name="D:\\pagefile.sys" set InitialSize=1024,MaximumSize=9216 &
+          net stop mongodb
+        shell: cmd
+        continue-on-error: true
 
       - name: Clean and download dependencies
         run: ./gradlew clean ${{ env.gradleArgs }}
@@ -295,17 +302,19 @@ jobs:
           - macos-11
         include:
         - os: windows-2022
-          testTaskName: mingwX64Test
+          targetName: mingwX64
         - os: ubuntu-20.04
-          testTaskName: linuxX64Test
+          targetName: linuxX64
         - os: ubuntu-18.04
-          testTaskName: linuxX64Test
+          targetName: linuxX64
         - os: macos-12
-          testTaskName: macosX64Test
+          targetName: macosX64
         - os: macos-11
-          testTaskName: macosX64Test
+          targetName: macosX64
     env:
-      gradleArgs: --scan "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
+      # FIXME there must be two or more targets, or we'll get error on `@OptionalExpectation`
+      # > Declaration annotated with '@OptionalExpectation' can only be used in common module sources
+      gradleArgs: --scan  "-Dmirai.target=jvm;${{ matrix.targetName }};!other" "-Pkotlin.compiler.execution.strategy=in-process" "-Dorg.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit -Dkotlin.daemon.jvm.options=--illegal-access=permit --add-opens java.base/java.util=ALL-UNNAMED"
       isMac: ${{ startsWith(matrix.os, 'macos') }}
       isWindows: ${{ startsWith(matrix.os, 'windows') }}
       isUbuntu: ${{ startsWith(matrix.os, 'ubuntu') }}
@@ -374,12 +383,6 @@ jobs:
         continue-on-error: true
 
       - if: ${{ env.isWindows == 'true' }}
-        name: Setup C++ Toolchain Environment on Windows
-        run: |
-          'echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.32.31326\bin\Hostx64\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
-          'echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append'
-
-      - if: ${{ env.isWindows == 'true' }}
         name: Install OpenSSL & cURL on Windows
         run: |
           echo "set(VCPKG_BUILD_TYPE release)" | Out-File -FilePath "$env:VCPKG_INSTALLATION_ROOT\triplets\x64-windows.cmake" -Encoding utf8 -Append
@@ -393,10 +396,10 @@ jobs:
         run: ./gradlew clean ${{ env.gradleArgs }}
 
       - name: "Test mirai-core-utils for ${{ matrix.os }}"
-        run: ./gradlew :mirai-core-utils:${{ matrix.testTaskName }} ${{ env.gradleArgs }}
+        run: ./gradlew :mirai-core-utils:${{ matrix.targetName }}Test ${{ env.gradleArgs }}
 
       - name: "Test mirai-core-api for ${{ matrix.os }}"
-        run: ./gradlew :mirai-core-api:${{ matrix.testTaskName }} ${{ env.gradleArgs }}
+        run: ./gradlew :mirai-core-api:${{ matrix.targetName }}Test ${{ env.gradleArgs }}
 
       - name: "Test mirai-core for ${{ matrix.os }}"
-        run: ./gradlew :mirai-core:${{ matrix.testTaskName }} ${{ env.gradleArgs }}
+        run: ./gradlew :mirai-core:${{ matrix.targetName }}Test ${{ env.gradleArgs }}

--- a/buildSrc/src/main/kotlin/BinaryCompatibilityConfigurator.kt
+++ b/buildSrc/src/main/kotlin/BinaryCompatibilityConfigurator.kt
@@ -21,7 +21,7 @@ import java.io.File
  */
 
 object BinaryCompatibilityConfigurator {
-    fun Project.configureBinaryValidators(vararg targetNames: String) {
+    fun Project.configureBinaryValidators(targetNames: Set<String>) {
         targetNames.forEach { configureBinaryValidator(it) }
     }
 

--- a/buildSrc/src/main/kotlin/HmppConfigure.kt
+++ b/buildSrc/src/main/kotlin/HmppConfigure.kt
@@ -74,7 +74,7 @@ enum class HostArch {
 
 /// eg. "!a;!b" means to enable all targets but a or b
 /// eg. "a;b;!other" means to disable all targets but a or b
-val ENABLED_TARGET = System.getProperty(
+val ENABLED_TARGETS = System.getProperty(
     "mirai.target",
     if (IDEA_ACTIVE)
         "jvm;android;${HOST_KIND.targetName};!other"
@@ -82,16 +82,16 @@ val ENABLED_TARGET = System.getProperty(
         ""
 ).split(';').toSet()
 
-fun isTargetEnable(name: String): Boolean {
+fun isTargetEnabled(name: String): Boolean {
     return when {
-        name in ENABLED_TARGET -> true
-        "!$name" in ENABLED_TARGET -> false
-        else -> "!other" !in ENABLED_TARGET
+        name in ENABLED_TARGETS -> true
+        "!$name" in ENABLED_TARGETS -> false
+        else -> "!other" !in ENABLED_TARGETS
     }
 }
 
 fun Set<String>.filterTargets() =
-    this.filter { isTargetEnable(it) }.toSet()
+    this.filter { isTargetEnabled(it) }.toSet()
 
 val MAC_TARGETS: Set<String> =
     setOf(
@@ -151,7 +151,7 @@ fun Project.configureJvmTargetsHierarchical() {
             }
         }
 
-        if (isTargetEnable("android")) {
+        if (isTargetEnabled("android")) {
             if (isAndroidSDKAvailable) {
                 jvm("android") {
                     attributes.attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
@@ -168,7 +168,7 @@ fun Project.configureJvmTargetsHierarchical() {
             }
         }
 
-        if (isTargetEnable("jvm")) {
+        if (isTargetEnabled("jvm")) {
             jvm("jvm") {
 
             }

--- a/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
+++ b/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
@@ -31,6 +31,7 @@ abstract class AbstractTest {
 
     @OptIn(ExperimentalStdlibApi::class)
     fun runGradle(vararg arguments: String) {
+        System.gc()
         GradleRunner.create()
             .withProjectDir(tempDir)
             .withPluginClasspath()
@@ -40,7 +41,7 @@ abstract class AbstractTest {
             .withArguments(buildList {
                 addAll(arguments)
                 add("-Pkotlin.compiler.execution.strategy=in-process")
-                add("-Dorg.gradle.jvmargs=-Xmx512m -Dfile.encoding=UTF-8")
+                add("-Dorg.gradle.jvmargs=-Xmx256m -Dfile.encoding=UTF-8")
             })
             .build()
     }

--- a/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
+++ b/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
@@ -29,6 +29,7 @@ abstract class AbstractTest {
     lateinit var propertiesFile: File
 
 
+    @OptIn(ExperimentalStdlibApi::class)
     fun runGradle(vararg arguments: String) {
         GradleRunner.create()
             .withProjectDir(tempDir)
@@ -36,7 +37,7 @@ abstract class AbstractTest {
             .withGradleVersion("7.2")
             .forwardOutput()
             .withEnvironment(System.getenv())
-            .withArguments(mutableListOf<String>().apply {
+            .withArguments(buildList {
                 addAll(arguments)
                 add("-Pkotlin.compiler.execution.strategy=in-process")
                 add("-Dorg.gradle.jvmargs=-Xmx512m -Dfile.encoding=UTF-8")

--- a/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
+++ b/mirai-console/tools/gradle-plugin/src/integTest/kotlin/AbstractTest.kt
@@ -29,14 +29,19 @@ abstract class AbstractTest {
     lateinit var propertiesFile: File
 
 
-    fun gradleRunner(): GradleRunner {
-        println(PluginUnderTestMetadataReading.readImplementationClasspath())
-        return GradleRunner.create()
+    fun runGradle(vararg arguments: String) {
+        GradleRunner.create()
             .withProjectDir(tempDir)
             .withPluginClasspath()
             .withGradleVersion("7.2")
             .forwardOutput()
             .withEnvironment(System.getenv())
+            .withArguments(mutableListOf<String>().apply {
+                addAll(arguments)
+                add("-Pkotlin.compiler.execution.strategy=in-process")
+                add("-Dorg.gradle.jvmargs=-Xmx512m -Dfile.encoding=UTF-8")
+            })
+            .build()
     }
 
     @BeforeEach

--- a/mirai-console/tools/gradle-plugin/src/integTest/kotlin/TestBuildPlugin.kt
+++ b/mirai-console/tools/gradle-plugin/src/integTest/kotlin/TestBuildPlugin.kt
@@ -88,9 +88,7 @@ class TestBuildPlugin : AbstractTest() {
         """.trimIndent()
         )
 
-        gradleRunner()
-            .withArguments(":buildPlugin", "--stacktrace", "--info")
-            .build()
+        runGradle(":buildPlugin", "--stacktrace", "--info")
 
 
         ZipFile(findJar()).use { zipFile ->
@@ -174,9 +172,7 @@ class TestBuildPlugin : AbstractTest() {
         """.trimIndent()
         )
 
-        gradleRunner()
-            .withArguments(":buildPlugin", "--stacktrace", "--info")
-            .build()
+        runGradle(":buildPlugin", "--stacktrace", "--info")
 
 
         ZipFile(findJar()).use { zipFile ->
@@ -242,9 +238,7 @@ class TestBuildPlugin : AbstractTest() {
         """.trimIndent()
         )
 
-        gradleRunner()
-            .withArguments(":buildPlugin", "--stacktrace", "--info")
-            .build()
+        runGradle(":buildPlugin", "--stacktrace", "--info")
 
 
         ZipFile(findJar()).use { zipFile ->
@@ -311,9 +305,7 @@ class TestBuildPlugin : AbstractTest() {
         """.trimIndent()
         )
 
-        gradleRunner()
-            .withArguments(":buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle(":buildPlugin", "dependencies", "--stacktrace", "--info")
         checkOutput()
 
         ZipFile(findJar()).use { zipFile ->
@@ -334,9 +326,7 @@ class TestBuildPlugin : AbstractTest() {
             }
         """.trimIndent()
         )
-        gradleRunner()
-            .withArguments("buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle("buildPlugin", "dependencies", "--stacktrace", "--info")
         checkOutput()
     }
 
@@ -349,9 +339,7 @@ class TestBuildPlugin : AbstractTest() {
             }
         """.trimIndent()
         )
-        gradleRunner()
-            .withArguments("buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle("buildPlugin", "dependencies", "--stacktrace", "--info")
 
         ZipFile(findJar()).use { zipFile ->
 
@@ -372,9 +360,7 @@ class TestBuildPlugin : AbstractTest() {
             }
         """.trimIndent()
         )
-        gradleRunner()
-            .withArguments("buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle("buildPlugin", "dependencies", "--stacktrace", "--info")
 
         ZipFile(findJar()).use { zipFile ->
 
@@ -397,9 +383,7 @@ class TestBuildPlugin : AbstractTest() {
             }
         """.trimIndent()
         )
-        gradleRunner()
-            .withArguments("buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle("buildPlugin", "dependencies", "--stacktrace", "--info")
 
         ZipFile(findJar()).use { zipFile ->
 
@@ -423,9 +407,7 @@ class TestBuildPlugin : AbstractTest() {
             }
         """.trimIndent()
         )
-        gradleRunner()
-            .withArguments("buildPlugin", "dependencies", "--stacktrace", "--info")
-            .build()
+        runGradle("buildPlugin", "dependencies", "--stacktrace", "--info")
         ZipFile(findJar()).use { zipFile ->
             assertNotNull(zipFile.getEntry("cn/hutool/core/annotation/Alias.class"))
 

--- a/mirai-console/tools/gradle-plugin/src/integTest/kotlin/TestPluginApply.kt
+++ b/mirai-console/tools/gradle-plugin/src/integTest/kotlin/TestPluginApply.kt
@@ -15,8 +15,6 @@ class TestPluginApply : AbstractTest() {
 
     @Test
     fun `can apply plugin`() {
-        gradleRunner()
-            .withArguments("clean", "--stacktrace")
-            .build()
+        runGradle("clean", "--stacktrace")
     }
 }

--- a/mirai-core-api/build.gradle.kts
+++ b/mirai-core-api/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
             }
         }
 
-        val jvmBaseMain by getting {
+        findByName("jvmBaseMain")?.apply {
             dependencies {
                 api(`kotlinx-coroutines-jdk8`) // use -jvm modules for this magic target 'jvmBase'
                 implementation(`jetbrains-annotations`)
@@ -64,34 +64,32 @@ kotlin {
             }
         }
 
-        if (isAndroidSDKAvailable) {
-            val androidMain by getting {
-                dependsOn(commonMain)
-                dependencies {
-                    compileOnly(`android-runtime`)
+        findByName("androidMain")?.apply {
+            dependsOn(commonMain)
+            dependencies {
+                compileOnly(`android-runtime`)
 //                    api(`ktor-client-android`)
-                }
             }
         }
 
-        val jvmMain by getting {
+        findByName("jvmMain")?.apply {
 
         }
 
-        val jvmTest by getting {
+        findByName("jvmTest")?.apply {
             dependencies {
                 runtimeOnly(files("build/classes/kotlin/jvm/test")) // classpath is not properly set by IDE
             }
         }
 
-        val nativeMain by getting {
+        findByName("nativeMain")?.apply {
             dependencies {
             }
         }
     }
 }
 
-if (isAndroidSDKAvailable) {
+if (tasks.findByName("androidMainClasses") != null) {
     tasks.register("checkAndroidApiLevel") {
         doFirst {
             analyzes.AndroidApiLevelCheck.check(
@@ -107,4 +105,4 @@ if (isAndroidSDKAvailable) {
 }
 
 configureMppPublishing()
-configureBinaryValidators("jvm", "android")
+configureBinaryValidators(setOf("jvm", "android").filterTargets())

--- a/mirai-core-api/src/nativeMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/nativeMain/kotlin/message/data/FileMessage.kt
@@ -12,7 +12,6 @@ package net.mamoe.mirai.message.data
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import me.him188.kotlin.jvm.blocking.bridge.JvmBlockingBridge
 import net.mamoe.mirai.Mirai
 import net.mamoe.mirai.contact.FileSupported
 import net.mamoe.mirai.contact.file.AbsoluteFile
@@ -42,7 +41,6 @@ import net.mamoe.mirai.utils.safeCast
 @Serializable(FileMessage.Serializer::class)
 @SerialName(FileMessage.SERIAL_NAME)
 @NotStableForInheritance
-@JvmBlockingBridge
 public actual interface FileMessage : MessageContent, ConstrainSingle, CodableMessage {
     /**
      * 服务器需要的某种 ID.

--- a/mirai-core-utils/build.gradle.kts
+++ b/mirai-core-utils/build.gradle.kts
@@ -47,31 +47,31 @@ kotlin {
             }
         }
 
-        val jvmBaseMain by getting {
+        findByName("jvmBaseMain")?.apply {
             dependencies {
                 implementation(`jetbrains-annotations`)
             }
         }
 
-        if (isAndroidSDKAvailable) {
-            val androidMain by getting {
-                //
-                dependencies {
-                    compileOnly(`android-runtime`)
+        findByName("androidMain")?.apply {
+            //
+            dependencies {
+                compileOnly(`android-runtime`)
 //                    api1(`ktor-client-android`)
-                }
             }
         }
 
-        val jvmMain by getting
+        findByName("jvmMain")?.apply {
 
-        val jvmTest by getting {
+        }
+
+        findByName("jvmTest")?.apply {
             dependencies {
                 runtimeOnly(files("build/classes/kotlin/jvm/test")) // classpath is not properly set by IDE
             }
         }
 
-        val nativeMain by getting {
+        findByName("nativeMain")?.apply {
             dependencies {
 //                implementation("com.soywiz.korlibs.krypto:krypto:2.4.12") // ':mirai-core-utils:compileNativeMainKotlinMetadata' fails because compiler cannot find reference
             }
@@ -79,7 +79,7 @@ kotlin {
     }
 }
 
-if (isAndroidSDKAvailable) {
+if (tasks.findByName("androidMainClasses") != null) {
     tasks.register("checkAndroidApiLevel") {
         doFirst {
             analyzes.AndroidApiLevelCheck.check(

--- a/mirai-core/build.gradle.kts
+++ b/mirai-core/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
             }
         }
 
-        val jvmBaseMain by getting {
+        findByName("jvmBaseMain")?.apply {
             dependencies {
                 implementation(bouncycastle)
                 implementation(`log4j-api`)
@@ -65,45 +65,43 @@ kotlin {
             }
         }
 
-        val jvmBaseTest by getting {
+        findByName("jvmBaseTest")?.apply {
             dependencies {
                 implementation(`kotlinx-coroutines-debug`)
             }
         }
 
-        if (isAndroidSDKAvailable) {
-            val androidMain by getting {
-                dependsOn(commonMain)
-                dependencies {
-                    compileOnly(`android-runtime`)
-                }
+        findByName("androidMain")?.apply {
+            dependsOn(commonMain)
+            dependencies {
+                compileOnly(`android-runtime`)
             }
-            val androidTest by getting {
-                dependencies {
-                    implementation(kotlin("test", Versions.kotlinCompiler))
-                    implementation(kotlin("test-junit5", Versions.kotlinCompiler))
-                    implementation(kotlin("test-annotations-common"))
-                    implementation(kotlin("test-common"))
-                    //implementation("org.bouncycastle:bcprov-jdk15on:1.64")
-                }
+        }
+        findByName("androidTest")?.apply {
+            dependencies {
+                implementation(kotlin("test", Versions.kotlinCompiler))
+                implementation(kotlin("test-junit5", Versions.kotlinCompiler))
+                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test-common"))
+                //implementation("org.bouncycastle:bcprov-jdk15on:1.64")
             }
         }
 
-        val jvmMain by getting {
+        findByName("jvmMain")?.apply {
             dependencies {
                 //implementation("org.bouncycastle:bcprov-jdk15on:1.64")
                 // api(kotlinx("coroutines-debug", Versions.coroutines))
             }
         }
 
-        val jvmTest by getting {
+        findByName("jvmTest")?.apply {
             dependencies {
                 api(`kotlinx-coroutines-debug`)
                 //  implementation("net.mamoe:mirai-login-solver-selenium:1.0-dev-14")
             }
         }
 
-        val nativeMain by getting {
+        findByName("nativeMain")?.apply {
             dependencies {
             }
         }
@@ -188,7 +186,7 @@ afterEvaluate {
     }
 }
 
-if (isAndroidSDKAvailable) {
+if (tasks.findByName("androidMainClasses") != null) {
     tasks.register("checkAndroidApiLevel") {
         doFirst {
             analyzes.AndroidApiLevelCheck.check(
@@ -204,4 +202,4 @@ if (isAndroidSDKAvailable) {
 }
 
 configureMppPublishing()
-configureBinaryValidators("jvm", "android")
+configureBinaryValidators(setOf("jvm", "android").filterTargets())

--- a/mirai-core/build.gradle.kts
+++ b/mirai-core/build.gradle.kts
@@ -151,7 +151,7 @@ kotlin {
             }
         }
 
-        val darwinMain by getting {
+        findByName("darwinMain")?.apply {
             dependencies {
                 implementation(`ktor-client-darwin`)
             }

--- a/mirai-core/src/commonTest/kotlin/message/data/ContentEqualsTest.kt
+++ b/mirai-core/src/commonTest/kotlin/message/data/ContentEqualsTest.kt
@@ -9,6 +9,7 @@
 
 package net.mamoe.mirai.internal.message.data
 
+import net.mamoe.mirai.internal.test.AbstractTest
 import net.mamoe.mirai.message.data.*
 import net.mamoe.mirai.utils.safeCast
 import kotlin.test.Test
@@ -26,7 +27,7 @@ internal class TestConstrainSingleMessage : ConstrainSingle, Any() {
         get() = Key
 }
 
-internal class ContentEqualsTest {
+internal class ContentEqualsTest: AbstractTest() {
 
     @Test
     fun testContentEquals() {


### PR DESCRIPTION
- 修复在Windows下使用IDEA打开后编译出错的问题（原有的部分`IDEA_ACTIVE`的优化只适用于MacOS）
- 允许通过`mirai.target`指定需要config的target，且在actions中尽可能减少不必要的target，以减少内存及时间
- 为 JVM (Windows) 任务也设置虚拟内存，防止出错
- 修复Windows Native Target