### PR TITLE
feat: 支持CompositeCommand间组合

### DIFF
--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -379,6 +379,9 @@ public abstract class net/mamoe/mirai/console/command/CompositeCommand : net/mam
 	public fun getUsage ()Ljava/lang/String;
 }
 
+protected abstract interface annotation class net/mamoe/mirai/console/command/CompositeCommand$ChildCommand : java/lang/annotation/Annotation {
+}
+
 protected abstract interface annotation class net/mamoe/mirai/console/command/CompositeCommand$Description : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/String;
 }

--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -19,7 +19,6 @@ public abstract interface class net/mamoe/mirai/console/MiraiConsole : kotlinx/c
 
 public final class net/mamoe/mirai/console/MiraiConsole$INSTANCE : net/mamoe/mirai/console/MiraiConsole {
 	public static synthetic fun addBot$default (Lnet/mamoe/mirai/console/MiraiConsole$INSTANCE;JLjava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lnet/mamoe/mirai/Bot;
-	public static synthetic fun addBot$default (Lnet/mamoe/mirai/console/MiraiConsole$INSTANCE;JLnet/mamoe/mirai/auth/BotAuthorization;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lnet/mamoe/mirai/Bot;
 	public static synthetic fun addBot$default (Lnet/mamoe/mirai/console/MiraiConsole$INSTANCE;J[BLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lnet/mamoe/mirai/Bot;
 	public fun getBuildDate ()Ljava/time/Instant;
 	public fun getBuiltInPluginLoaders ()Ljava/util/List;
@@ -40,11 +39,6 @@ public abstract interface class net/mamoe/mirai/console/MiraiConsoleFrontEndDesc
 	public abstract fun getVendor ()Ljava/lang/String;
 	public abstract fun getVersion ()Lnet/mamoe/mirai/console/util/SemVersion;
 	public fun render ()Ljava/lang/String;
-}
-
-public final class net/mamoe/mirai/console/MiraiConsoleImplementation$ConsoleLaunchOptions {
-	public field crashWhenPluginLoadFailed Z
-	public fun <init> ()V
 }
 
 public final class net/mamoe/mirai/console/MiraiConsoleKt {
@@ -110,10 +104,13 @@ public final class net/mamoe/mirai/console/command/BuiltInCommands {
 
 public final class net/mamoe/mirai/console/command/BuiltInCommands$AutoLoginCommand : net/mamoe/mirai/console/command/CompositeCommand, net/mamoe/mirai/console/command/BuiltInCommandInternal {
 	public static final field INSTANCE Lnet/mamoe/mirai/console/command/BuiltInCommands$AutoLoginCommand;
+	public final fun add (Lnet/mamoe/mirai/console/command/CommandSender;JLjava/lang/String;Lnet/mamoe/mirai/console/internal/data/builtins/AutoLoginConfig$Account$PasswordKind;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun add$default (Lnet/mamoe/mirai/console/command/BuiltInCommands$AutoLoginCommand;Lnet/mamoe/mirai/console/command/CommandSender;JLjava/lang/String;Lnet/mamoe/mirai/console/internal/data/builtins/AutoLoginConfig$Account$PasswordKind;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun clear (Lnet/mamoe/mirai/console/command/CommandSender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun list (Lnet/mamoe/mirai/console/command/CommandSender;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun remove (Lnet/mamoe/mirai/console/command/CommandSender;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeConfig (Lnet/mamoe/mirai/console/command/CommandSender;JLnet/mamoe/mirai/console/internal/data/builtins/AutoLoginConfig$Account$ConfigurationKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setConfig (Lnet/mamoe/mirai/console/command/CommandSender;JLnet/mamoe/mirai/console/internal/data/builtins/AutoLoginConfig$Account$ConfigurationKey;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class net/mamoe/mirai/console/command/BuiltInCommands$HelpCommand : net/mamoe/mirai/console/command/SimpleCommand, net/mamoe/mirai/console/command/BuiltInCommandInternal {
@@ -177,6 +174,13 @@ public final class net/mamoe/mirai/console/command/Command$Companion {
 public abstract interface class net/mamoe/mirai/console/command/CommandContext {
 	public abstract fun getOriginalMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
 	public abstract fun getSender ()Lnet/mamoe/mirai/console/command/CommandSender;
+}
+
+public abstract class net/mamoe/mirai/console/command/CommandExecuteResult {
+	public abstract fun getCall ()Lnet/mamoe/mirai/console/command/parse/CommandCall;
+	public abstract fun getCommand ()Lnet/mamoe/mirai/console/command/Command;
+	public abstract fun getException ()Ljava/lang/Throwable;
+	public abstract fun getResolvedCall ()Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;
 }
 
 public final class net/mamoe/mirai/console/command/CommandExecuteResult$ExecutionFailed : net/mamoe/mirai/console/command/CommandExecuteResult$Failure {
@@ -249,6 +253,8 @@ public final class net/mamoe/mirai/console/command/CommandExecuteResult$Unresolv
 }
 
 public final class net/mamoe/mirai/console/command/CommandExecuteResultKt {
+	public static final synthetic fun isFailure (Lnet/mamoe/mirai/console/command/CommandExecuteResult;)Z
+	public static final synthetic fun isSuccess (Lnet/mamoe/mirai/console/command/CommandExecuteResult;)Z
 }
 
 public final class net/mamoe/mirai/console/command/CommandExecutionException : java/lang/RuntimeException {
@@ -261,9 +267,12 @@ public final class net/mamoe/mirai/console/command/CommandExecutionException : j
 
 public abstract interface class net/mamoe/mirai/console/command/CommandManager {
 	public static final field INSTANCE Lnet/mamoe/mirai/console/command/CommandManager$INSTANCE;
+	public fun executeCommand (Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;Z)Lnet/mamoe/mirai/console/command/CommandExecuteResult;
+	public fun executeCommand (Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun executeCommand$default (Lnet/mamoe/mirai/console/command/CommandManager;Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun executeCommand$default (Lnet/mamoe/mirai/console/command/CommandManager;Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;ZILjava/lang/Object;)Lnet/mamoe/mirai/console/command/CommandExecuteResult;
 	public static synthetic fun executeCommand$default (Lnet/mamoe/mirai/console/command/CommandManager;Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun executeCommand$suspendImpl (Lnet/mamoe/mirai/console/command/CommandManager;Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun findDuplicateCommand (Lnet/mamoe/mirai/console/command/Command;)Lnet/mamoe/mirai/console/command/Command;
 	public abstract fun getAllRegisteredCommands ()Ljava/util/List;
 	public abstract fun getCommandPrefix ()Ljava/lang/String;
@@ -277,6 +286,7 @@ public abstract interface class net/mamoe/mirai/console/command/CommandManager {
 }
 
 public final class net/mamoe/mirai/console/command/CommandManager$INSTANCE : net/mamoe/mirai/console/command/CommandManager {
+	public fun executeCommand (Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final synthetic fun findDuplicate (Lnet/mamoe/mirai/console/command/Command;)Lnet/mamoe/mirai/console/command/Command;
 	public fun findDuplicateCommand (Lnet/mamoe/mirai/console/command/Command;)Lnet/mamoe/mirai/console/command/Command;
 	public fun getAllRegisteredCommands ()Ljava/util/List;
@@ -296,6 +306,9 @@ public final class net/mamoe/mirai/console/command/CommandManager$INSTANCE : net
 }
 
 public final class net/mamoe/mirai/console/command/CommandManagerKt {
+	public static final synthetic fun execute0 (Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/console/command/CommandSender;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun execute0 (Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/console/command/CommandSender;[Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun execute0 (Lnet/mamoe/mirai/console/command/CommandSender;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun execute0$default (Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/console/command/CommandSender;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun execute0$default (Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/console/command/CommandSender;[Lnet/mamoe/mirai/message/data/Message;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun execute0$default (Lnet/mamoe/mirai/console/command/CommandSender;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -318,7 +331,6 @@ public abstract interface class net/mamoe/mirai/console/command/CommandSender : 
 	public static fun from (Lnet/mamoe/mirai/event/events/GroupMessageEvent;)Lnet/mamoe/mirai/console/command/MemberCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/GroupTempMessageEvent;)Lnet/mamoe/mirai/console/command/GroupTempCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/MessageEvent;)Lnet/mamoe/mirai/console/command/CommandSenderOnMessage;
-	public static fun from (Lnet/mamoe/mirai/event/events/MessageSyncEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync;
 	public static fun from (Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessage;
 	public static fun from (Lnet/mamoe/mirai/event/events/StrangerMessageEvent;)Lnet/mamoe/mirai/console/command/StrangerCommandSenderOnMessage;
 	public abstract fun getBot ()Lnet/mamoe/mirai/Bot;
@@ -343,7 +355,6 @@ public final class net/mamoe/mirai/console/command/CommandSender$Companion {
 	public final fun from (Lnet/mamoe/mirai/event/events/GroupMessageEvent;)Lnet/mamoe/mirai/console/command/MemberCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/GroupTempMessageEvent;)Lnet/mamoe/mirai/console/command/GroupTempCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/MessageEvent;)Lnet/mamoe/mirai/console/command/CommandSenderOnMessage;
-	public final fun from (Lnet/mamoe/mirai/event/events/MessageSyncEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync;
 	public final fun from (Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;)Lnet/mamoe/mirai/console/command/OtherClientCommandSenderOnMessage;
 	public final fun from (Lnet/mamoe/mirai/event/events/StrangerMessageEvent;)Lnet/mamoe/mirai/console/command/StrangerCommandSenderOnMessage;
 	public final fun of (Lnet/mamoe/mirai/contact/Friend;)Lnet/mamoe/mirai/console/command/FriendCommandSender;
@@ -363,7 +374,6 @@ public final class net/mamoe/mirai/console/command/CommandSenderKt {
 	public static final fun isConsole (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 	public static final fun isNotConsole (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 	public static final fun isNotUser (Lnet/mamoe/mirai/console/command/CommandSender;)Z
-	public static final fun isSystem (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 	public static final fun isUser (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 }
 
@@ -549,11 +559,6 @@ public final class net/mamoe/mirai/console/command/OtherClientCommandSenderOnMes
 	public fun getFromEvent ()Lnet/mamoe/mirai/event/events/OtherClientMessageEvent;
 }
 
-public final class net/mamoe/mirai/console/command/OtherClientCommandSenderOnMessageSync : net/mamoe/mirai/console/command/OtherClientCommandSender, net/mamoe/mirai/console/command/CommandSenderOnMessage {
-	public synthetic fun getFromEvent ()Lnet/mamoe/mirai/event/events/MessageEvent;
-	public fun getFromEvent ()Lnet/mamoe/mirai/event/events/MessageSyncEvent;
-}
-
 public abstract interface class net/mamoe/mirai/console/command/PluginCustomCommandSender : net/mamoe/mirai/console/command/CommandSender, net/mamoe/mirai/console/command/SystemCommandSender {
 	public abstract fun getOwner ()Lnet/mamoe/mirai/console/plugin/Plugin;
 	public fun getPermitteeId ()Lnet/mamoe/mirai/console/permission/PermitteeId;
@@ -631,6 +636,16 @@ public abstract interface class net/mamoe/mirai/console/command/UserCommandSende
 	public abstract fun getUser ()Lnet/mamoe/mirai/contact/User;
 }
 
+public abstract class net/mamoe/mirai/console/command/descriptor/AbstractCommandParameter : net/mamoe/mirai/console/command/descriptor/CommandParameter {
+	public fun <init> ()V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class net/mamoe/mirai/console/command/descriptor/AbstractCommandSignature : net/mamoe/mirai/console/command/descriptor/CommandSignature {
+	public fun <init> ()V
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class net/mamoe/mirai/console/command/descriptor/AbstractCommandValueArgumentParser : net/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser {
 	public static final field Companion Lnet/mamoe/mirai/console/command/descriptor/AbstractCommandValueArgumentParser$Companion;
 	public fun <init> ()V
@@ -641,6 +656,12 @@ public abstract class net/mamoe/mirai/console/command/descriptor/AbstractCommand
 public final class net/mamoe/mirai/console/command/descriptor/AbstractCommandValueArgumentParser$Companion {
 	public static synthetic fun checkArgument$default (Lnet/mamoe/mirai/console/command/descriptor/AbstractCommandValueArgumentParser$Companion;Lnet/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static synthetic fun illegalArgument$default (Lnet/mamoe/mirai/console/command/descriptor/AbstractCommandValueArgumentParser$Companion;Lnet/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Ljava/lang/Void;
+}
+
+public abstract class net/mamoe/mirai/console/command/descriptor/AbstractCommandValueParameter : net/mamoe/mirai/console/command/descriptor/AbstractCommandParameter, net/mamoe/mirai/console/command/descriptor/CommandValueParameter {
+	public fun accepting (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/CommandArgumentContext;)Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance;
+	protected fun acceptingImpl (Lkotlin/reflect/KType;Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/CommandArgumentContext;)Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class net/mamoe/mirai/console/command/descriptor/AbstractCommandValueParameter$UserDefinedType : net/mamoe/mirai/console/command/descriptor/AbstractCommandValueParameter {
@@ -662,6 +683,14 @@ public final class net/mamoe/mirai/console/command/descriptor/AbstractCommandVal
 }
 
 public final class net/mamoe/mirai/console/command/descriptor/AbstractCommandValueParameter$UserDefinedType$Companion {
+}
+
+public abstract class net/mamoe/mirai/console/command/descriptor/ArgumentAcceptance {
+	public static final field Companion Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAcceptanceLevel ()I
+	public static final fun isAcceptable (Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance;)Z
+	public static final fun isNotAcceptable (Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance;)Z
 }
 
 public final class net/mamoe/mirai/console/command/descriptor/ArgumentAcceptance$Companion {
@@ -816,6 +845,12 @@ public final class net/mamoe/mirai/console/command/descriptor/CommandArgumentPar
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public class net/mamoe/mirai/console/command/descriptor/CommandDeclarationClashException : net/mamoe/mirai/console/command/descriptor/CommandDeclarationException {
+	public fun <init> (Lnet/mamoe/mirai/console/command/Command;Ljava/util/List;)V
+	public final fun getCommand ()Lnet/mamoe/mirai/console/command/Command;
+	public final fun getSignatures ()Ljava/util/List;
+}
+
 public class net/mamoe/mirai/console/command/descriptor/CommandDeclarationException : java/lang/RuntimeException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -823,7 +858,32 @@ public class net/mamoe/mirai/console/command/descriptor/CommandDeclarationExcept
 	public fun <init> (Ljava/lang/Throwable;)V
 }
 
+public abstract interface class net/mamoe/mirai/console/command/descriptor/CommandParameter {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getType ()Lkotlin/reflect/KType;
+	public abstract fun isOptional ()Z
+}
+
+public abstract class net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter : net/mamoe/mirai/console/command/descriptor/AbstractCommandParameter, net/mamoe/mirai/console/command/descriptor/CommandParameter {
+	public static final field Companion Lnet/mamoe/mirai/console/command/descriptor/CommandReceiverParameter$Companion;
+	public static final field NAME Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+}
+
 public final class net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter$Companion {
+}
+
+public final class net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter$Context : net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter {
+	public fun <init> (ZLkotlin/reflect/KType;)V
+	public synthetic fun <init> (ZLkotlin/reflect/KType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getType ()Lkotlin/reflect/KType;
+	public fun isOptional ()Z
+}
+
+public final class net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter$Sender : net/mamoe/mirai/console/command/descriptor/CommandReceiverParameter {
+	public fun <init> (ZLkotlin/reflect/KType;)V
+	public fun getType ()Lkotlin/reflect/KType;
+	public fun isOptional ()Z
 }
 
 public class net/mamoe/mirai/console/command/descriptor/CommandResolutionException : java/lang/RuntimeException {
@@ -831,6 +891,19 @@ public class net/mamoe/mirai/console/command/descriptor/CommandResolutionExcepti
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class net/mamoe/mirai/console/command/descriptor/CommandSignature {
+	public abstract fun call (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getReceiverParameter ()Lnet/mamoe/mirai/console/command/descriptor/CommandReceiverParameter;
+	public abstract fun getValueParameters ()Ljava/util/List;
+}
+
+public class net/mamoe/mirai/console/command/descriptor/CommandSignatureImpl : net/mamoe/mirai/console/command/descriptor/AbstractCommandSignature, net/mamoe/mirai/console/command/descriptor/CommandSignature {
+	public fun <init> (Lnet/mamoe/mirai/console/command/descriptor/CommandReceiverParameter;Ljava/util/List;Lkotlin/jvm/functions/Function3;)V
+	public fun call (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getReceiverParameter ()Lnet/mamoe/mirai/console/command/descriptor/CommandReceiverParameter;
+	public fun getValueParameters ()Ljava/util/List;
 }
 
 public abstract interface class net/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser {
@@ -844,6 +917,19 @@ public abstract interface class net/mamoe/mirai/console/command/descriptor/Comma
 public final class net/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser$Companion {
 	public final fun map (Lnet/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser;Lkotlin/jvm/functions/Function2;)Lnet/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser;
 	public final fun parse (Lnet/mamoe/mirai/console/command/descriptor/CommandValueArgumentParser;Lnet/mamoe/mirai/message/data/Message;Lnet/mamoe/mirai/console/command/CommandSender;)Ljava/lang/Object;
+}
+
+public abstract interface class net/mamoe/mirai/console/command/descriptor/CommandValueParameter : net/mamoe/mirai/console/command/descriptor/CommandParameter {
+	public abstract fun accepting (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/CommandArgumentContext;)Lnet/mamoe/mirai/console/command/descriptor/ArgumentAcceptance;
+	public fun accepts (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/CommandArgumentContext;)Z
+	public abstract fun isVararg ()Z
+}
+
+public final class net/mamoe/mirai/console/command/descriptor/ContentStringTypeVariant : net/mamoe/mirai/console/command/descriptor/TypeVariant {
+	public static final field INSTANCE Lnet/mamoe/mirai/console/command/descriptor/ContentStringTypeVariant;
+	public fun getOutType ()Lkotlin/reflect/KType;
+	public synthetic fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Ljava/lang/Object;
+	public fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Ljava/lang/String;
 }
 
 public final class net/mamoe/mirai/console/command/descriptor/DoubleValueArgumentParser {
@@ -942,6 +1028,26 @@ public final class net/mamoe/mirai/console/command/descriptor/MappingCommandValu
 	public fun parse (Lnet/mamoe/mirai/message/data/MessageContent;Lnet/mamoe/mirai/console/command/CommandSender;)Ljava/lang/Object;
 }
 
+public final class net/mamoe/mirai/console/command/descriptor/MessageChainTypeVariant : net/mamoe/mirai/console/command/descriptor/TypeVariant {
+	public static final field INSTANCE Lnet/mamoe/mirai/console/command/descriptor/MessageChainTypeVariant;
+	public fun getOutType ()Lkotlin/reflect/KType;
+	public synthetic fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Ljava/lang/Object;
+	public fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Lnet/mamoe/mirai/message/data/MessageChain;
+}
+
+public final class net/mamoe/mirai/console/command/descriptor/MessageContentTypeVariant : net/mamoe/mirai/console/command/descriptor/TypeVariant {
+	public static final field INSTANCE Lnet/mamoe/mirai/console/command/descriptor/MessageContentTypeVariant;
+	public fun getOutType ()Lkotlin/reflect/KType;
+	public synthetic fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Ljava/lang/Object;
+	public fun mapValue (Lnet/mamoe/mirai/message/data/Message;)Lnet/mamoe/mirai/message/data/MessageContent;
+}
+
+public class net/mamoe/mirai/console/command/descriptor/NoValueArgumentMappingException : net/mamoe/mirai/console/command/descriptor/CommandResolutionException {
+	public fun <init> (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lkotlin/reflect/KType;)V
+	public final fun getArgument ()Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;
+	public final fun getForType ()Lkotlin/reflect/KType;
+}
+
 public final class net/mamoe/mirai/console/command/descriptor/PermissionIdValueArgumentParser {
 	public static final field INSTANCE Lnet/mamoe/mirai/console/command/descriptor/PermissionIdValueArgumentParser;
 	public synthetic fun parse (Ljava/lang/String;Lnet/mamoe/mirai/console/command/CommandSender;)Ljava/lang/Object;
@@ -989,6 +1095,12 @@ public final class net/mamoe/mirai/console/command/descriptor/StringValueArgumen
 	public static final field INSTANCE Lnet/mamoe/mirai/console/command/descriptor/StringValueArgumentParser;
 	public synthetic fun parse (Ljava/lang/String;Lnet/mamoe/mirai/console/command/CommandSender;)Ljava/lang/Object;
 	public fun parse (Ljava/lang/String;Lnet/mamoe/mirai/console/command/CommandSender;)Ljava/lang/String;
+}
+
+public class net/mamoe/mirai/console/command/descriptor/SubcommandDeclarationClashException : net/mamoe/mirai/console/command/descriptor/CommandDeclarationException {
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public final fun getOwner ()Ljava/lang/Object;
+	public final fun getSignatures ()Ljava/util/List;
 }
 
 public final class net/mamoe/mirai/console/command/descriptor/TypeVariant$Companion {
@@ -1043,11 +1155,48 @@ public abstract class net/mamoe/mirai/console/command/java/JSimpleCommand : net/
 	protected fun setPrefixOptional (Z)V
 }
 
+public abstract interface class net/mamoe/mirai/console/command/parse/CommandArgument {
+}
+
+public abstract interface class net/mamoe/mirai/console/command/parse/CommandCall {
+	public abstract fun getCalleeName ()Ljava/lang/String;
+	public abstract fun getCaller ()Lnet/mamoe/mirai/console/command/CommandSender;
+	public abstract fun getOriginalMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
+	public abstract fun getValueArguments ()Ljava/util/List;
+}
+
+public final class net/mamoe/mirai/console/command/parse/CommandCallImpl : net/mamoe/mirai/console/command/parse/CommandCall {
+	public fun <init> (Lnet/mamoe/mirai/console/command/CommandSender;Ljava/lang/String;Ljava/util/List;Lnet/mamoe/mirai/message/data/MessageChain;)V
+	public fun getCalleeName ()Ljava/lang/String;
+	public fun getCaller ()Lnet/mamoe/mirai/console/command/CommandSender;
+	public fun getOriginalMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
+	public fun getValueArguments ()Ljava/util/List;
+}
+
 public final class net/mamoe/mirai/console/command/parse/CommandCallParser$Companion {
 	public final fun parseCommandCall (Lnet/mamoe/mirai/message/data/MessageChain;Lnet/mamoe/mirai/console/command/CommandSender;)Lnet/mamoe/mirai/console/command/parse/CommandCall;
 }
 
+public abstract interface class net/mamoe/mirai/console/command/parse/CommandValueArgument : net/mamoe/mirai/console/command/parse/CommandArgument {
+	public abstract fun getType ()Lkotlin/reflect/KType;
+	public abstract fun getTypeVariants ()Ljava/util/List;
+	public abstract fun getValue ()Lnet/mamoe/mirai/message/data/Message;
+}
+
 public final class net/mamoe/mirai/console/command/parse/CommandValueArgumentKt {
+	public static final fun mapToType (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lkotlin/reflect/KType;)Ljava/lang/Object;
+	public static final fun mapToTypeOrNull (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lkotlin/reflect/KType;)Ljava/lang/Object;
+	public static final fun mapValue (Lnet/mamoe/mirai/console/command/parse/CommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/TypeVariant;)Ljava/lang/Object;
+}
+
+public abstract interface class net/mamoe/mirai/console/command/resolve/CommandCallInterceptor {
+	public static final field Companion Lnet/mamoe/mirai/console/command/resolve/CommandCallInterceptor$Companion;
+	public fun interceptBeforeCall (Lnet/mamoe/mirai/message/data/Message;Lnet/mamoe/mirai/console/command/CommandSender;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
+	public fun interceptCall (Lnet/mamoe/mirai/console/command/parse/CommandCall;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
+	public fun interceptResolvedCall (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
+	public static fun intercepted (Lnet/mamoe/mirai/console/command/parse/CommandCall;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
+	public static fun intercepted (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
+	public static fun intercepted (Lnet/mamoe/mirai/message/data/Message;Lnet/mamoe/mirai/console/command/CommandSender;)Lnet/mamoe/mirai/console/command/resolve/InterceptResult;
 }
 
 public final class net/mamoe/mirai/console/command/resolve/CommandCallInterceptor$Companion {
@@ -1057,22 +1206,85 @@ public final class net/mamoe/mirai/console/command/resolve/CommandCallIntercepto
 }
 
 public final class net/mamoe/mirai/console/command/resolve/CommandCallInterceptorKt {
+	public static final synthetic fun InterceptedReason (Ljava/lang/String;)Lnet/mamoe/mirai/console/command/resolve/InterceptedReason;
+	public static final fun fold (Lnet/mamoe/mirai/console/command/resolve/InterceptResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun getOrElse (Lnet/mamoe/mirai/console/command/resolve/InterceptResult;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface class net/mamoe/mirai/console/command/resolve/CommandCallResolver {
+	public static final field Companion Lnet/mamoe/mirai/console/command/resolve/CommandCallResolver$Companion;
+	public abstract fun resolve (Lnet/mamoe/mirai/console/command/parse/CommandCall;)Lnet/mamoe/mirai/console/command/resolve/CommandResolveResult;
 }
 
 public final class net/mamoe/mirai/console/command/resolve/CommandCallResolver$Companion {
 }
 
 public final class net/mamoe/mirai/console/command/resolve/CommandCallResolverKt {
+	public static final fun fold (Lnet/mamoe/mirai/console/command/resolve/CommandResolveResult;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun getOrElse (Lnet/mamoe/mirai/console/command/resolve/CommandResolveResult;Lkotlin/jvm/functions/Function1;)Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;
+}
+
+public final class net/mamoe/mirai/console/command/resolve/CommandResolveResult {
+	public fun <init> (Lnet/mamoe/mirai/console/command/CommandExecuteResult$Failure;)V
+	public fun <init> (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;)V
+	public final fun getCall ()Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;
+	public final fun getFailure ()Lnet/mamoe/mirai/console/command/CommandExecuteResult$Failure;
+}
+
+public final class net/mamoe/mirai/console/command/resolve/InterceptResult {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Lnet/mamoe/mirai/console/command/resolve/InterceptedReason;)V
+	public final fun getReason ()Lnet/mamoe/mirai/console/command/resolve/InterceptedReason;
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public abstract interface class net/mamoe/mirai/console/command/resolve/InterceptedReason {
+	public static final field Companion Lnet/mamoe/mirai/console/command/resolve/InterceptedReason$Companion;
+	public abstract fun getMessage ()Ljava/lang/String;
 }
 
 public final class net/mamoe/mirai/console/command/resolve/InterceptedReason$Companion {
 	public final fun create (Ljava/lang/String;)Lnet/mamoe/mirai/console/command/resolve/InterceptedReason;
 }
 
+public abstract interface class net/mamoe/mirai/console/command/resolve/ResolvedCommandCall {
+	public static final field Companion Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall$Companion;
+	public abstract fun getCallee ()Lnet/mamoe/mirai/console/command/Command;
+	public abstract fun getCalleeSignature ()Lnet/mamoe/mirai/console/command/descriptor/CommandSignature;
+	public abstract fun getCaller ()Lnet/mamoe/mirai/console/command/CommandSender;
+	public abstract fun getOriginalMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
+	public abstract fun getRawValueArguments ()Ljava/util/List;
+	public abstract fun getResolvedValueArguments ()Ljava/util/List;
+}
+
 public final class net/mamoe/mirai/console/command/resolve/ResolvedCommandCall$Companion {
 }
 
+public final class net/mamoe/mirai/console/command/resolve/ResolvedCommandCallImpl : net/mamoe/mirai/console/command/resolve/ResolvedCommandCall {
+	public fun <init> (Lnet/mamoe/mirai/console/command/CommandSender;Lnet/mamoe/mirai/console/command/Command;Lnet/mamoe/mirai/console/command/descriptor/CommandSignature;Ljava/util/List;Lnet/mamoe/mirai/console/command/descriptor/CommandArgumentContext;Lnet/mamoe/mirai/message/data/MessageChain;)V
+	public fun getCallee ()Lnet/mamoe/mirai/console/command/Command;
+	public fun getCalleeSignature ()Lnet/mamoe/mirai/console/command/descriptor/CommandSignature;
+	public fun getCaller ()Lnet/mamoe/mirai/console/command/CommandSender;
+	public fun getOriginalMessage ()Lnet/mamoe/mirai/message/data/MessageChain;
+	public fun getRawValueArguments ()Ljava/util/List;
+	public fun getResolvedValueArguments ()Ljava/util/List;
+}
+
 public final class net/mamoe/mirai/console/command/resolve/ResolvedCommandCallKt {
+	public static final fun call (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class net/mamoe/mirai/console/command/resolve/ResolvedCommandValueArgument {
+	public fun <init> (Lnet/mamoe/mirai/console/command/descriptor/CommandValueParameter;Ljava/lang/Object;)V
+	public final fun component1 ()Lnet/mamoe/mirai/console/command/descriptor/CommandValueParameter;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lnet/mamoe/mirai/console/command/descriptor/CommandValueParameter;Ljava/lang/Object;)Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandValueArgument;
+	public static synthetic fun copy$default (Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandValueArgument;Lnet/mamoe/mirai/console/command/descriptor/CommandValueParameter;Ljava/lang/Object;ILjava/lang/Object;)Lnet/mamoe/mirai/console/command/resolve/ResolvedCommandValueArgument;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getParameter ()Lnet/mamoe/mirai/console/command/descriptor/CommandValueParameter;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class net/mamoe/mirai/console/data/AbstractPluginData : net/mamoe/mirai/console/data/PluginData {
@@ -1113,7 +1325,6 @@ public abstract interface class net/mamoe/mirai/console/data/PluginConfig : net/
 
 public abstract interface class net/mamoe/mirai/console/data/PluginData {
 	public abstract fun getSaveName ()Ljava/lang/String;
-	public fun getSaveType ()Lnet/mamoe/mirai/console/data/PluginData$SaveType;
 	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public abstract fun getUpdaterSerializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -1290,52 +1501,7 @@ public final class net/mamoe/mirai/console/data/java/JavaAutoSavePluginData$Comp
 	public final fun createKType (Ljava/lang/Class;[Lkotlin/reflect/KType;)Lkotlin/reflect/KType;
 }
 
-public final class net/mamoe/mirai/console/enduserreadme/EndUserReadme {
-	public static final field Companion Lnet/mamoe/mirai/console/enduserreadme/EndUserReadme$Companion;
-	public static final field DELAY Ljava/lang/String;
-	public static final field PAUSE Ljava/lang/String;
-	public fun <init> ()V
-	public final fun put (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public final fun putAll (Ljava/lang/String;)V
-}
-
-public final class net/mamoe/mirai/console/enduserreadme/EndUserReadme$Companion {
-}
-
-public final class net/mamoe/mirai/console/enduserreadme/EndUserReadme$Render {
-	public fun <init> ()V
-	public final fun delay ()V
-	public final fun delay (I)V
-	public final fun msg (Ljava/lang/String;)V
-	public final fun pause ()V
-	public final fun plusAssign (Ljava/lang/String;)V
-	public final fun render ()Ljava/lang/String;
-	public final fun unaryPlus (Ljava/lang/String;)V
-}
-
-public abstract class net/mamoe/mirai/console/events/AutoLoginEvent : net/mamoe/mirai/event/AbstractEvent, net/mamoe/mirai/console/events/ConsoleEvent, net/mamoe/mirai/event/events/BotEvent {
-}
-
-public final class net/mamoe/mirai/console/events/AutoLoginEvent$Failure : net/mamoe/mirai/console/events/AutoLoginEvent {
-	public fun getBot ()Lnet/mamoe/mirai/Bot;
-	public final fun getCause ()Ljava/lang/Throwable;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class net/mamoe/mirai/console/events/AutoLoginEvent$Success : net/mamoe/mirai/console/events/AutoLoginEvent {
-	public fun getBot ()Lnet/mamoe/mirai/Bot;
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class net/mamoe/mirai/console/events/ConsoleEvent : net/mamoe/mirai/event/Event {
-}
-
-public final class net/mamoe/mirai/console/events/EndUserReadmeInitializeEvent : net/mamoe/mirai/event/AbstractEvent, net/mamoe/mirai/console/events/ConsoleEvent {
-	public final fun getReadme ()Lnet/mamoe/mirai/console/enduserreadme/EndUserReadme;
-}
-
-public final class net/mamoe/mirai/console/events/StartupEvent : net/mamoe/mirai/event/AbstractEvent, net/mamoe/mirai/console/events/ConsoleEvent {
-	public final fun getTimestamp ()J
 }
 
 public abstract class net/mamoe/mirai/console/extension/AbstractExtensionPoint : net/mamoe/mirai/console/extension/ExtensionPoint {
@@ -1395,10 +1561,18 @@ public final class net/mamoe/mirai/console/extension/PluginComponentStorage {
 	public fun <init> (Lnet/mamoe/mirai/console/plugin/Plugin;)V
 	public final fun contribute (Lnet/mamoe/mirai/console/extension/ExtensionPoint;Lkotlin/jvm/functions/Function0;)V
 	public final fun contributeBotConfigurationAlterer (Lnet/mamoe/mirai/console/extensions/BotConfigurationAlterer;)V
+	public final fun contributeCommandCallInterceptor (Lkotlin/jvm/functions/Function0;)V
+	public final fun contributeCommandCallInterceptorProvider (Lnet/mamoe/mirai/console/extensions/CommandCallInterceptorProvider;)V
+	public final fun contributeCommandCallParser (Lkotlin/jvm/functions/Function0;)V
+	public final fun contributeCommandCallParserProvider (Lnet/mamoe/mirai/console/extensions/CommandCallParserProvider;)V
+	public final fun contributeCommandCallResolver (Lkotlin/jvm/functions/Function0;)V
+	public final fun contributeCommandCallResolverProvider (Lnet/mamoe/mirai/console/extensions/CommandCallResolverProvider;)V
+	public final fun contributePermissionService (Lkotlin/jvm/functions/Function0;)V
 	public final fun contributePermissionServiceProvider (Lkotlin/jvm/functions/Function0;)V
+	public final fun contributePluginLoader (Lkotlin/jvm/functions/Function0;)V
 	public final fun contributePluginLoaderProvider (Lkotlin/jvm/functions/Function0;)V
 	public final fun contributePostStartupExtension (Lnet/mamoe/mirai/console/extensions/PostStartupExtension;)V
-	public final synthetic fun contributeSingletonExtensionSelector (Lkotlin/jvm/functions/Function0;)V
+	public final fun contributeSingletonExtensionSelector (Lkotlin/jvm/functions/Function0;)V
 	public final fun runAfterStartup (Lkotlin/jvm/functions/Function0;)V
 }
 
@@ -1415,6 +1589,63 @@ public abstract interface class net/mamoe/mirai/console/extensions/BotConfigurat
 }
 
 public final class net/mamoe/mirai/console/extensions/BotConfigurationAlterer$ExtensionPoint : net/mamoe/mirai/console/extension/AbstractExtensionPoint {
+}
+
+public abstract interface class net/mamoe/mirai/console/extensions/CommandCallInterceptorProvider : net/mamoe/mirai/console/extension/InstanceExtension {
+	public static final field ExtensionPoint Lnet/mamoe/mirai/console/extensions/CommandCallInterceptorProvider$ExtensionPoint;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallInterceptorProvider$ExtensionPoint : net/mamoe/mirai/console/extension/AbstractInstanceExtensionPoint {
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallInterceptorProviderImpl : net/mamoe/mirai/console/extensions/CommandCallInterceptorProvider {
+	public fun <init> (Lnet/mamoe/mirai/console/command/resolve/CommandCallInterceptor;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/resolve/CommandCallInterceptor;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallInterceptorProviderImplLazy : net/mamoe/mirai/console/extensions/CommandCallInterceptorProvider {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/resolve/CommandCallInterceptor;
+}
+
+public abstract interface class net/mamoe/mirai/console/extensions/CommandCallParserProvider : net/mamoe/mirai/console/extension/InstanceExtension {
+	public static final field ExtensionPoint Lnet/mamoe/mirai/console/extensions/CommandCallParserProvider$ExtensionPoint;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallParserProvider$ExtensionPoint : net/mamoe/mirai/console/extension/AbstractInstanceExtensionPoint {
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallParserProviderImpl : net/mamoe/mirai/console/extensions/CommandCallParserProvider {
+	public fun <init> (Lnet/mamoe/mirai/console/command/parse/CommandCallParser;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/parse/CommandCallParser;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallParserProviderImplLazy : net/mamoe/mirai/console/extensions/CommandCallParserProvider {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/parse/CommandCallParser;
+}
+
+public abstract interface class net/mamoe/mirai/console/extensions/CommandCallResolverProvider : net/mamoe/mirai/console/extension/InstanceExtension {
+	public static final field ExtensionPoint Lnet/mamoe/mirai/console/extensions/CommandCallResolverProvider$ExtensionPoint;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallResolverProvider$ExtensionPoint : net/mamoe/mirai/console/extension/AbstractInstanceExtensionPoint {
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallResolverProviderImpl : net/mamoe/mirai/console/extensions/CommandCallResolverProvider {
+	public fun <init> (Lnet/mamoe/mirai/console/command/resolve/CommandCallResolver;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/resolve/CommandCallResolver;
+}
+
+public final class net/mamoe/mirai/console/extensions/CommandCallResolverProviderImplLazy : net/mamoe/mirai/console/extensions/CommandCallResolverProvider {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun getInstance ()Ljava/lang/Object;
+	public fun getInstance ()Lnet/mamoe/mirai/console/command/resolve/CommandCallResolver;
 }
 
 public abstract interface class net/mamoe/mirai/console/extensions/PermissionServiceProvider : net/mamoe/mirai/console/extension/InstanceExtension {
@@ -1482,17 +1713,6 @@ public final class net/mamoe/mirai/console/extensions/SingletonExtensionSelector
 	public final fun getPlugin ()Lnet/mamoe/mirai/console/plugin/Plugin;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class net/mamoe/mirai/console/fontend/ProcessProgress : java/io/Closeable {
-	public abstract fun close ()V
-	public abstract fun markFailed ()V
-	public abstract fun rerender ()V
-	public abstract fun setTotalSize (J)V
-	public abstract fun update (J)V
-	public abstract fun update (JJ)V
-	public fun updateText (Ljava/lang/CharSequence;)V
-	public abstract fun updateText (Ljava/lang/String;)V
 }
 
 public final class net/mamoe/mirai/console/logging/AbstractLoggerController$LogPriority$Companion {
@@ -1787,7 +2007,6 @@ public abstract interface class net/mamoe/mirai/console/permission/PermitteeId {
 	public static fun getAllParentsWithSelf (Lnet/mamoe/mirai/console/permission/PermitteeId;)Lkotlin/sequences/Sequence;
 	public abstract fun getDirectParents ()[Lnet/mamoe/mirai/console/permission/PermitteeId;
 	public static fun hasChild (Lnet/mamoe/mirai/console/permission/PermitteeId;Lnet/mamoe/mirai/console/permission/PermitteeId;)Z
-	public static fun isChildOf (Lnet/mamoe/mirai/console/permission/PermitteeId;Lnet/mamoe/mirai/console/permission/PermitteeId;)Z
 }
 
 public final class net/mamoe/mirai/console/permission/PermitteeId$Companion {
@@ -1800,11 +2019,6 @@ public final class net/mamoe/mirai/console/permission/PermitteeId$Companion {
 	public final synthetic fun getPermitteeId (Lnet/mamoe/mirai/contact/User;)Lnet/mamoe/mirai/console/permission/AbstractPermitteeId$ExactUser;
 	public final synthetic fun getPermitteeIdOnTemp (Lnet/mamoe/mirai/contact/Member;)Lnet/mamoe/mirai/console/permission/AbstractPermitteeId$ExactGroupTemp;
 	public final fun hasChild (Lnet/mamoe/mirai/console/permission/PermitteeId;Lnet/mamoe/mirai/console/permission/PermitteeId;)Z
-	public final fun isChildOf (Lnet/mamoe/mirai/console/permission/PermitteeId;Lnet/mamoe/mirai/console/permission/PermitteeId;)Z
-}
-
-public abstract interface class net/mamoe/mirai/console/plugin/NotYetLoadedPlugin : net/mamoe/mirai/console/plugin/Plugin {
-	public abstract fun resolve ()Lnet/mamoe/mirai/console/plugin/Plugin;
 }
 
 public abstract interface class net/mamoe/mirai/console/plugin/Plugin : net/mamoe/mirai/console/command/CommandOwner {
@@ -1901,6 +2115,7 @@ public final class net/mamoe/mirai/console/plugin/ResourceContainer$Companion {
 
 public final class net/mamoe/mirai/console/plugin/center/PluginCenter$PluginInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lnet/mamoe/mirai/console/plugin/center/PluginCenter$PluginInfo$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/mamoe/mirai/console/plugin/center/PluginCenter$PluginInfo;
@@ -1916,6 +2131,7 @@ public final class net/mamoe/mirai/console/plugin/center/PluginCenter$PluginInfo
 
 public final class net/mamoe/mirai/console/plugin/center/PluginCenter$PluginInsight$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lnet/mamoe/mirai/console/plugin/center/PluginCenter$PluginInsight$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/mamoe/mirai/console/plugin/center/PluginCenter$PluginInsight;
@@ -1995,12 +2211,8 @@ public abstract class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPlugin : net
 	public fun <init> ()V
 	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;)V
-	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAutoSaveIntervalMillis ()Lkotlin/ranges/LongRange;
 	public final fun getDataHolderName ()Ljava/lang/String;
-	public final fun getDescription ()Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;
 	protected final fun getJvmPluginClasspath ()Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginClasspath;
 	public final fun getLoader ()Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginLoader;
 	public synthetic fun getLoader ()Lnet/mamoe/mirai/console/plugin/loader/PluginLoader;
@@ -2009,8 +2221,6 @@ public abstract class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPlugin : net
 	public final fun reloadPluginData (Lnet/mamoe/mirai/console/data/PluginData;)V
 	public final fun savePluginConfig (Lnet/mamoe/mirai/console/data/PluginConfig;)V
 	public final fun savePluginData (Lnet/mamoe/mirai/console/data/PluginData;)V
-	protected final fun services (Ljava/lang/Class;)Lkotlin/Lazy;
-	protected final synthetic fun services (Lkotlin/reflect/KClass;)Lkotlin/Lazy;
 }
 
 public final class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPluginKt {
@@ -2021,12 +2231,10 @@ public final class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPluginKt {
 }
 
 public abstract class net/mamoe/mirai/console/plugin/jvm/JavaPlugin : net/mamoe/mirai/console/plugin/jvm/AbstractJvmPlugin, net/mamoe/mirai/console/plugin/jvm/JvmPlugin {
-	public fun <init> ()V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;)V
 	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDescription ()Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;
 	public final fun getScheduler ()Lnet/mamoe/mirai/console/plugin/jvm/JavaPluginScheduler;
 }
 
@@ -2069,12 +2277,6 @@ public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginClas
 	public abstract fun getPluginFile ()Ljava/io/File;
 	public abstract fun getPluginIndependentLibrariesClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getPluginSharedLibrariesClassLoader ()Ljava/lang/ClassLoader;
-	public abstract fun getShouldBeResolvableToIndependent ()Z
-	public abstract fun getShouldResolveConsoleSystemResource ()Z
-	public abstract fun getShouldResolveIndependent ()Z
-	public abstract fun setShouldBeResolvableToIndependent (Z)V
-	public abstract fun setShouldResolveConsoleSystemResource (Z)V
-	public abstract fun setShouldResolveIndependent (Z)V
 }
 
 public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginDescription : net/mamoe/mirai/console/plugin/description/PluginDescription {
@@ -2142,12 +2344,10 @@ public final class net/mamoe/mirai/console/plugin/jvm/JvmPluginLoader$BuiltIn : 
 }
 
 public abstract class net/mamoe/mirai/console/plugin/jvm/KotlinPlugin : net/mamoe/mirai/console/plugin/jvm/AbstractJvmPlugin, net/mamoe/mirai/console/plugin/jvm/JvmPlugin {
-	public fun <init> ()V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;)V
 	public fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;)V
 	public synthetic fun <init> (Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDescription ()Lnet/mamoe/mirai/console/plugin/jvm/JvmPluginDescription;
 }
 
 public abstract class net/mamoe/mirai/console/plugin/loader/AbstractFilePluginLoader : net/mamoe/mirai/console/plugin/loader/FilePluginLoader {
@@ -2209,7 +2409,6 @@ public class net/mamoe/mirai/console/util/AnsiMessageBuilder : java/io/Serializa
 	public fun gray ()Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public fun green ()Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public fun hashCode ()I
-	public static final fun isAnsiSupported (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 	public fun lightBlue ()Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public fun lightCyan ()Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public fun lightGreen ()Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
@@ -2233,7 +2432,6 @@ public final class net/mamoe/mirai/console/util/AnsiMessageBuilder$Companion {
 	public final fun from (Ljava/lang/StringBuilder;)Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public final fun from (Ljava/lang/StringBuilder;Z)Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
 	public static synthetic fun from$default (Lnet/mamoe/mirai/console/util/AnsiMessageBuilder$Companion;Ljava/lang/StringBuilder;ZILjava/lang/Object;)Lnet/mamoe/mirai/console/util/AnsiMessageBuilder;
-	public final fun isAnsiSupported (Lnet/mamoe/mirai/console/command/CommandSender;)Z
 }
 
 public final class net/mamoe/mirai/console/util/AnsiMessageBuilderKt {

--- a/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-2022 Mamoe Technologies and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/mamoe/mirai/blob/dev/LICENSE
+ */
+
+package net.mamoe.mirai.console.command
+
+import net.mamoe.mirai.console.command.descriptor.*
+import net.mamoe.mirai.console.compiler.common.ResolveContext
+import net.mamoe.mirai.console.compiler.common.ResolveContext.Kind.RESTRICTED_CONSOLE_COMMAND_OWNER
+import net.mamoe.mirai.console.internal.command.GroupedCommandSubCommandAnnotationResolver
+import net.mamoe.mirai.console.internal.command.SubCommandReflector
+import net.mamoe.mirai.console.compiler.common.ResolveContext.Kind.COMMAND_NAME
+import net.mamoe.mirai.console.util.ConsoleExperimentalApi
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+
+public abstract class AbstractSubCommandGroup(
+    overrideContext: CommandArgumentContext = EmptyCommandArgumentContext,
+) : CommandArgumentContextAware, SubCommandGroup {
+
+    private val reflector by lazy { SubCommandReflector(this, GroupedCommandSubCommandAnnotationResolver) }
+
+    @ExperimentalCommandDescriptors
+    public final override val provideOverloads: List<CommandSignatureFromKFunction> by lazy {
+        reflector.findSubCommands().also {
+            reflector.validate(it)
+        }
+    }
+
+    /**
+     * 标记一个属性为子指令集合
+     */
+    @Retention(RUNTIME)
+    @Target(PROPERTY)
+    protected annotation class AnotherCombinedCommand(
+    )
+
+    /**
+     * 标记一个函数为子指令, 当 [value] 为空时使用函数名.
+     * @param value 子指令名
+     */
+    @Retention(RUNTIME)
+    @Target(FUNCTION)
+    protected annotation class AnotherSubCommand(
+        @ResolveContext(COMMAND_NAME) vararg val value: String = [],
+    )
+
+    /** 指令描述 */
+    @Retention(RUNTIME)
+    @Target(FUNCTION)
+    protected annotation class AnotherDescription(val value: String)
+
+    /** 参数名, 由具体Command决定用途 */
+    @ConsoleExperimentalApi("Classname might change")
+    @Retention(RUNTIME)
+    @Target(AnnotationTarget.VALUE_PARAMETER)
+    protected annotation class AnotherName(val value: String)
+
+    /**
+     * 智能参数解析环境
+     */ // open since 2.12
+    public override val context: CommandArgumentContext = CommandArgumentContext.Builtins + overrideContext
+
+}
+
+

--- a/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
@@ -27,7 +27,7 @@ public abstract class AbstractSubCommandGroup(
     private val reflector by lazy { SubCommandReflector(this, GroupedCommandSubCommandAnnotationResolver) }
 
     @ExperimentalCommandDescriptors
-    public final override val provideOverloads: List<CommandSignatureFromKFunction> by lazy {
+    public final override val overloads: List<CommandSignatureFromKFunction> by lazy {
         reflector.findSubCommands().also {
             reflector.validate(it)
         }

--- a/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/AbstractSubCommandGroup.kt
@@ -10,15 +10,8 @@
 package net.mamoe.mirai.console.command
 
 import net.mamoe.mirai.console.command.descriptor.*
-import net.mamoe.mirai.console.compiler.common.ResolveContext
-import net.mamoe.mirai.console.compiler.common.ResolveContext.Kind.RESTRICTED_CONSOLE_COMMAND_OWNER
 import net.mamoe.mirai.console.internal.command.GroupedCommandSubCommandAnnotationResolver
 import net.mamoe.mirai.console.internal.command.SubCommandReflector
-import net.mamoe.mirai.console.compiler.common.ResolveContext.Kind.COMMAND_NAME
-import net.mamoe.mirai.console.util.ConsoleExperimentalApi
-import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY
 
 public abstract class AbstractSubCommandGroup(
     overrideContext: CommandArgumentContext = EmptyCommandArgumentContext,
@@ -32,35 +25,6 @@ public abstract class AbstractSubCommandGroup(
             reflector.validate(it)
         }
     }
-
-    /**
-     * 标记一个属性为子指令集合
-     */
-    @Retention(RUNTIME)
-    @Target(PROPERTY)
-    protected annotation class AnotherCombinedCommand(
-    )
-
-    /**
-     * 标记一个函数为子指令, 当 [value] 为空时使用函数名.
-     * @param value 子指令名
-     */
-    @Retention(RUNTIME)
-    @Target(FUNCTION)
-    protected annotation class AnotherSubCommand(
-        @ResolveContext(COMMAND_NAME) vararg val value: String = [],
-    )
-
-    /** 指令描述 */
-    @Retention(RUNTIME)
-    @Target(FUNCTION)
-    protected annotation class AnotherDescription(val value: String)
-
-    /** 参数名, 由具体Command决定用途 */
-    @ConsoleExperimentalApi("Classname might change")
-    @Retention(RUNTIME)
-    @Target(AnnotationTarget.VALUE_PARAMETER)
-    protected annotation class AnotherName(val value: String)
 
     /**
      * 智能参数解析环境

--- a/mirai-console/backend/mirai-console/src/command/BuiltInCommands.kt
+++ b/mirai-console/backend/mirai-console/src/command/BuiltInCommands.kt
@@ -23,6 +23,9 @@ import net.mamoe.mirai.console.MiraiConsoleImplementation
 import net.mamoe.mirai.console.MiraiConsoleImplementation.ConsoleDataScope.Companion.get
 import net.mamoe.mirai.console.command.CommandManager.INSTANCE.allRegisteredCommands
 import net.mamoe.mirai.console.command.CommandManager.INSTANCE.register
+import net.mamoe.mirai.console.command.SubCommandGroup.Description
+import net.mamoe.mirai.console.command.SubCommandGroup.Name
+import net.mamoe.mirai.console.command.SubCommandGroup.SubCommand
 import net.mamoe.mirai.console.command.descriptor.CommandArgumentParserException
 import net.mamoe.mirai.console.command.descriptor.CommandValueArgumentParser.Companion.map
 import net.mamoe.mirai.console.command.descriptor.PermissionIdValueArgumentParser

--- a/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
@@ -20,6 +20,7 @@ import net.mamoe.mirai.console.permission.Permission
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
 
 
 /**
@@ -97,6 +98,13 @@ public abstract class CompositeCommand(
     private val reflector by lazy { CommandReflector(this, CompositeCommandSubCommandAnnotationResolver) }
 
     @ExperimentalCommandDescriptors
+    public val overloadImpls: List<@JvmWildcard CommandSignatureFromKFunctionImpl> by lazy {
+        reflector.findSubCommands().also {
+            reflector.validate(it)
+        }
+    }
+
+    @ExperimentalCommandDescriptors
     public final override val overloads: List<@JvmWildcard CommandSignatureFromKFunction> by lazy {
         reflector.findSubCommands().also {
             reflector.validate(it)
@@ -124,6 +132,14 @@ public abstract class CompositeCommand(
     @Target(FUNCTION)
     protected annotation class SubCommand(
         @ResolveContext(COMMAND_NAME) vararg val value: String = [],
+    )
+
+    /**
+     * 标记一个属性为子指令集合
+     */
+    @Retention(RUNTIME)
+    @Target(PROPERTY)
+    protected annotation class ChildCommand(
     )
 
     /** 指令描述 */

--- a/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
@@ -106,9 +106,7 @@ public abstract class CompositeCommand(
 
     @ExperimentalCommandDescriptors
     public final override val overloads: List<@JvmWildcard CommandSignatureFromKFunction> by lazy {
-        reflector.findSubCommands().also {
-            reflector.validate(it)
-        }
+        overloadImpls
     }
 
     /**

--- a/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
@@ -18,9 +18,9 @@ import net.mamoe.mirai.console.internal.command.CommandReflector
 import net.mamoe.mirai.console.internal.command.CompositeCommandSubCommandAnnotationResolver
 import net.mamoe.mirai.console.permission.Permission
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
+import kotlin.DeprecationLevel.*
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY
 
 /**
  * 复合指令. 指令注册时候会通过反射构造指令解析器.
@@ -92,7 +92,7 @@ public abstract class CompositeCommand(
     parentPermission: Permission = owner.parentPermission,
     overrideContext: CommandArgumentContext = EmptyCommandArgumentContext,
 ) : Command, AbstractCommand(owner, primaryName, secondaryNames = secondaryNames, description, parentPermission),
-    CommandArgumentContextAware {
+    CommandArgumentContextAware, SubCommandGroup {
 
     private val reflector by lazy { CommandReflector(this, CompositeCommandSubCommandAnnotationResolver) }
 
@@ -116,34 +116,30 @@ public abstract class CompositeCommand(
      */ // open since 2.12
     public override val context: CommandArgumentContext = CommandArgumentContext.Builtins + overrideContext
 
-    /**
-     * 标记一个属性为子指令集合
-     */
-    @Retention(RUNTIME)
-    @Target(PROPERTY)
-    protected annotation class CombinedCommand(
-    )
 
-    /**
+/*    *//**
      * 标记一个函数为子指令, 当 [value] 为空时使用函数名.
      * @param value 子指令名
-     */
+     *//*
     @Retention(RUNTIME)
     @Target(FUNCTION)
+    @Deprecated(level = HIDDEN, message = "use SubCommandGroup.SubCommand")
     protected annotation class SubCommand(
         @ResolveContext(COMMAND_NAME) vararg val value: String = [],
     )
 
-    /** 指令描述 */
+    *//** 指令描述 *//*
     @Retention(RUNTIME)
     @Target(FUNCTION)
+    @Deprecated(level = HIDDEN, message = "use SubCommandGroup.Description")
     protected annotation class Description(val value: String)
 
-    /** 参数名, 将参与构成 [usage] */
+    *//** 参数名, 将参与构成 [usage] *//*
     @ConsoleExperimentalApi("Classname might change")
     @Retention(RUNTIME)
     @Target(AnnotationTarget.VALUE_PARAMETER)
-    protected annotation class Name(val value: String)
+    @Deprecated(level = HIDDEN, message = "use SubCommandGroup.Name")
+    protected annotation class Name(val value: String)*/
 }
 
 

--- a/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
@@ -22,7 +22,6 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
 
-
 /**
  * 复合指令. 指令注册时候会通过反射构造指令解析器.
  *
@@ -118,6 +117,14 @@ public abstract class CompositeCommand(
     public override val context: CommandArgumentContext = CommandArgumentContext.Builtins + overrideContext
 
     /**
+     * 标记一个属性为子指令集合
+     */
+    @Retention(RUNTIME)
+    @Target(PROPERTY)
+    protected annotation class CombinedCommand(
+    )
+
+    /**
      * 标记一个函数为子指令, 当 [value] 为空时使用函数名.
      * @param value 子指令名
      */
@@ -125,14 +132,6 @@ public abstract class CompositeCommand(
     @Target(FUNCTION)
     protected annotation class SubCommand(
         @ResolveContext(COMMAND_NAME) vararg val value: String = [],
-    )
-
-    /**
-     * 标记一个属性为子指令集合
-     */
-    @Retention(RUNTIME)
-    @Target(PROPERTY)
-    protected annotation class ChildCommand(
     )
 
     /** 指令描述 */

--- a/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/CompositeCommand.kt
@@ -98,15 +98,10 @@ public abstract class CompositeCommand(
     private val reflector by lazy { CommandReflector(this, CompositeCommandSubCommandAnnotationResolver) }
 
     @ExperimentalCommandDescriptors
-    public val overloadImpls: List<@JvmWildcard CommandSignatureFromKFunctionImpl> by lazy {
+    public final override val overloads: List<@JvmWildcard CommandSignatureFromKFunction> by lazy {
         reflector.findSubCommands().also {
             reflector.validate(it)
         }
-    }
-
-    @ExperimentalCommandDescriptors
-    public final override val overloads: List<@JvmWildcard CommandSignatureFromKFunction> by lazy {
-        overloadImpls
     }
 
     /**

--- a/mirai-console/backend/mirai-console/src/command/SimpleCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/SimpleCommand.kt
@@ -73,7 +73,6 @@ public abstract class SimpleCommand(
         }
     }
 
-
     /**
      * 自动根据带有 [Handler] 注解的函数签名生成 [usage]. 也可以被覆盖.
      */

--- a/mirai-console/backend/mirai-console/src/command/SimpleCommand.kt
+++ b/mirai-console/backend/mirai-console/src/command/SimpleCommand.kt
@@ -73,6 +73,7 @@ public abstract class SimpleCommand(
         }
     }
 
+
     /**
      * 自动根据带有 [Handler] 注解的函数签名生成 [usage]. 也可以被覆盖.
      */

--- a/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
@@ -2,6 +2,7 @@ package net.mamoe.mirai.console.command
 
 import net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunction
 import net.mamoe.mirai.console.command.descriptor.ExperimentalCommandDescriptors
+import net.mamoe.mirai.console.compiler.common.ResolveContext
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
 
 public interface SubCommandGroup {
@@ -11,5 +12,35 @@ public interface SubCommandGroup {
      */
     @ExperimentalCommandDescriptors
     public val overloads: List<@JvmWildcard CommandSignatureFromKFunction>
+
+    /**
+     * 标记一个属性为子指令集合，且使用flat策略
+     */
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.PROPERTY)
+    public annotation class FlattenSubCommands(
+    )
+
+    /**
+     * 1. 标记一个函数为子指令, 当 [value] 为空时使用函数名.
+     * 2. 标记一个属性为子指令集合，且使用sub策略
+     * @param value 子指令名
+     */
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+    public annotation class SubCommand(
+        @ResolveContext(ResolveContext.Kind.COMMAND_NAME) vararg val value: String = [],
+    )
+
+    /** 指令描述 */
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.FUNCTION)
+    public annotation class Description(val value: String)
+
+    /** 参数名, 由具体Command决定用途 */
+    @ConsoleExperimentalApi("Classname might change")
+    @Retention(AnnotationRetention.RUNTIME)
+    @Target(AnnotationTarget.VALUE_PARAMETER)
+    public annotation class Name(val value: String)
 
 }

--- a/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
@@ -1,0 +1,16 @@
+package net.mamoe.mirai.console.command
+
+import net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunction
+import net.mamoe.mirai.console.command.descriptor.ExperimentalCommandDescriptors
+import net.mamoe.mirai.console.util.ConsoleExperimentalApi
+
+public interface SubCommandGroup {
+
+    /**
+     * 被聚合时提供的子指令
+     */
+    @ConsoleExperimentalApi("Property name is experimental")
+    @ExperimentalCommandDescriptors
+    public val provideOverloads: List<@JvmWildcard CommandSignatureFromKFunction>
+
+}

--- a/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
+++ b/mirai-console/backend/mirai-console/src/command/SubCommandGroup.kt
@@ -9,8 +9,7 @@ public interface SubCommandGroup {
     /**
      * 被聚合时提供的子指令
      */
-    @ConsoleExperimentalApi("Property name is experimental")
     @ExperimentalCommandDescriptors
-    public val provideOverloads: List<@JvmWildcard CommandSignatureFromKFunction>
+    public val overloads: List<@JvmWildcard CommandSignatureFromKFunction>
 
 }

--- a/mirai-console/backend/mirai-console/src/command/descriptor/Exceptions.kt
+++ b/mirai-console/backend/mirai-console/src/command/descriptor/Exceptions.kt
@@ -42,6 +42,13 @@ public open class CommandDeclarationClashException(
     public val signatures: List<CommandSignature>,
 ) : CommandDeclarationException("Declaration clash for command '${command.primaryName}': \n${signatures.joinToString("\n")}")
 
+@ExperimentalCommandDescriptors
+public open class SubcommandDeclarationClashException(
+    public val owner: Any,
+    public val signatures: List<CommandSignature>,
+) : CommandDeclarationException("Declaration clash for owner '${owner::class.qualifiedName}': \n${signatures.joinToString("\n")}")
+
+
 public open class CommandDeclarationException : RuntimeException {
     public constructor() : super()
     public constructor(message: String?) : super(message)

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -87,11 +87,6 @@ internal object CompositeCommandSubCommandAnnotationResolver :
 
 }
 
-/*
- * - 不看Function上的Annotation
- * - 不从Function获取SubCommandNames
- * - 看Property上的Annotation
- */
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object GroupedCommandSubCommandAnnotationResolver :
     SubCommandAnnotationResolver<Any> {

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -227,7 +227,7 @@ internal class CommandReflector(
         }
     }
 
-    fun validate(signatures: List<CommandSignatureFromKFunctionImpl>) {
+    fun validate(signatures: List<CommandSignatureFromKFunction>) {
 
         data class ErasedParameterInfo(
             val index: Int,
@@ -267,7 +267,7 @@ internal class CommandReflector(
     }
 
     @Throws(IllegalCommandDeclarationException::class)
-    fun findSubCommands(): List<CommandSignatureFromKFunctionImpl> {
+    fun findSubCommands(): List<CommandSignatureFromKFunction> {
         val fromMemberFunctions = command::class.functions // exclude static later
             .asSequence()
             .filter { it.isSubCommandFunction() }
@@ -358,10 +358,10 @@ internal class CommandReflector(
             .filter { it is CompositeCommand }
             .flatMap { property ->
                 property as CompositeCommand
-                property.overloadImpls
+                property.overloads
             }.toList()
 
-        val list: MutableList<CommandSignatureFromKFunctionImpl> = ArrayList()
+        val list: MutableList<CommandSignatureFromKFunction> = ArrayList()
         list.addAll(fromMemberFunctions)
         list.addAll(fromMemberProperties)
         return list

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -66,7 +66,7 @@ internal fun Any.flattenCommandComponents(): MessageChain = buildMessageChain {
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object CompositeCommandSubCommandAnnotationResolver :
-    SubCommandAnnotationResolver {
+    SubCommandAnnotationResolver<Command> {
     override fun hasAnnotation(ownerCommand: Command, function: KFunction<*>) =
         function.hasAnnotation<CompositeCommand.SubCommand>()
 
@@ -82,14 +82,42 @@ internal object CompositeCommandSubCommandAnnotationResolver :
     override fun getDescription(ownerCommand: Command, function: KFunction<*>): String? =
         function.findAnnotation<CompositeCommand.Description>()?.value
 
-    override fun hasPropertyAnnotation(command: Command, property: KProperty<*>): Boolean =
-        property.hasAnnotation<CompositeCommand.ChildCommand>()
+    override fun hasPropertyAnnotation(command: Command, kProperty: KProperty<*>): Boolean =
+        kProperty.hasAnnotation<CompositeCommand.CombinedCommand>()
+
+}
+
+/*
+ * - 不看Function上的Annotation
+ * - 不从Function获取SubCommandNames
+ * - 看Property上的Annotation
+ */
+@Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+internal object GroupedCommandSubCommandAnnotationResolver :
+    SubCommandAnnotationResolver<Any> {
+    override fun hasAnnotation(ownerCommand: Any, function: KFunction<*>) =
+        function.hasAnnotation<AbstractSubCommandGroup.AnotherSubCommand>()
+
+    override fun getSubCommandNames(ownerCommand: Any, function: KFunction<*>): Array<out String> {
+        val annotated = function.findAnnotation<AbstractSubCommandGroup.AnotherSubCommand>()!!.value
+        return if (annotated.isEmpty()) arrayOf(function.name)
+        else annotated
+    }
+
+    override fun getAnnotatedName(ownerCommand: Any, parameter: KParameter): String? =
+        parameter.findAnnotation<AbstractSubCommandGroup.AnotherName>()?.value
+
+    override fun getDescription(ownerCommand: Any, function: KFunction<*>): String? =
+        function.findAnnotation<AbstractSubCommandGroup.AnotherDescription>()?.value
+
+    override fun hasPropertyAnnotation(command: Any, kProperty: KProperty<*>): Boolean =
+        kProperty.hasAnnotation<AbstractSubCommandGroup.AnotherCombinedCommand>()
 
 }
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object SimpleCommandSubCommandAnnotationResolver :
-    SubCommandAnnotationResolver {
+    SubCommandAnnotationResolver<Command> {
     override fun hasAnnotation(ownerCommand: Command, function: KFunction<*>) =
         function.hasAnnotation<SimpleCommand.Handler>()
 
@@ -105,12 +133,12 @@ internal object SimpleCommandSubCommandAnnotationResolver :
     override fun hasPropertyAnnotation(command: Command, kProperty: KProperty<*>): Boolean = false
 }
 
-internal interface SubCommandAnnotationResolver {
-    fun hasAnnotation(ownerCommand: Command, function: KFunction<*>): Boolean
-    fun getSubCommandNames(ownerCommand: Command, function: KFunction<*>): Array<out String>
-    fun getAnnotatedName(ownerCommand: Command, parameter: KParameter): String?
-    fun getDescription(ownerCommand: Command, function: KFunction<*>): String?
-    fun hasPropertyAnnotation(command: Command, kProperty: KProperty<*>): Boolean
+internal interface SubCommandAnnotationResolver<T> {
+    fun hasAnnotation(ownerCommand: T, function: KFunction<*>): Boolean
+    fun getSubCommandNames(ownerCommand: T, function: KFunction<*>): Array<out String>
+    fun getAnnotatedName(ownerCommand: T, parameter: KParameter): String?
+    fun getDescription(ownerCommand: T, function: KFunction<*>): String?
+    fun hasPropertyAnnotation(command: T, kProperty: KProperty<*>): Boolean
 }
 
 @ConsoleExperimentalApi
@@ -118,10 +146,10 @@ public class IllegalCommandDeclarationException : Exception {
     public override val message: String?
 
     public constructor(
-        ownerCommand: Command,
+        owner: Any,
         correspondingFunction: KFunction<*>,
         message: String?,
-    ) : super("Illegal command declaration: ${correspondingFunction.name} declared in ${ownerCommand::class.qualifiedName}") {
+    ) : super("Illegal command declaration: ${correspondingFunction.name} declared in ${owner::class.qualifiedName}") {
         this.message = message
     }
 
@@ -136,47 +164,8 @@ public class IllegalCommandDeclarationException : Exception {
 @OptIn(ExperimentalCommandDescriptors::class)
 internal class CommandReflector(
     val command: Command,
-    private val annotationResolver: SubCommandAnnotationResolver,
-) {
-
-    @Suppress("NOTHING_TO_INLINE")
-    private inline fun KFunction<*>.illegalDeclaration(
-        message: String,
-    ): Nothing {
-        throw IllegalCommandDeclarationException(command, this, message)
-    }
-
-    private fun KProperty<*>.isSubCommandProperty(): Boolean = annotationResolver.hasPropertyAnnotation(command, this)
-    private fun KFunction<*>.isSubCommandFunction(): Boolean = annotationResolver.hasAnnotation(command, this)
-    private fun KFunction<*>.checkExtensionReceiver() {
-        this.extensionReceiverParameter?.let { receiver ->
-            val classifier = receiver.type.classifierAsKClassOrNull()
-            if (classifier != null) {
-                if (!classifier.isSubclassOf(CommandSender::class) && !classifier.isSubclassOf(CommandContext::class)) {
-                    illegalDeclaration("Extension receiver parameter type is not subclass of CommandSender nor CommandContext.")
-                }
-            }
-        }
-    }
-
-    private fun KFunction<*>.checkNames() {
-        val names = annotationResolver.getSubCommandNames(command, this)
-        for (name in names) {
-            ILLEGAL_SUB_NAME_CHARS.find { it in name }?.let {
-                illegalDeclaration("'$it' is forbidden in command name.")
-            }
-        }
-    }
-
-    private fun KFunction<*>.checkModifiers() {
-        if (isInline) illegalDeclaration("Command function cannot be inline")
-        if (visibility == KVisibility.PRIVATE) illegalDeclaration("Command function must be accessible from Mirai Console, that is, effectively public.")
-        if (this.hasAnnotation<JvmStatic>()) illegalDeclaration("Command function must not be static.")
-
-        // should we allow abstract?
-
-        // if (isAbstract) illegalDeclaration("Command function cannot be abstract")
-    }
+    private val annotationResolver: SubCommandAnnotationResolver<Command>,
+) : SubCommandReflectible by SubCommandReflector(command, annotationResolver) {
 
     fun generateUsage(overloads: Iterable<CommandSignatureFromKFunction>): String {
         return generateUsage(command, annotationResolver, overloads)
@@ -185,7 +174,7 @@ internal class CommandReflector(
     companion object {
         fun generateUsage(
             command: Command,
-            annotationResolver: SubCommandAnnotationResolver?,
+            annotationResolver: SubCommandAnnotationResolver<Command>?,
             overloads: Iterable<CommandSignature>
         ): String {
             return overloads.joinToString("\n") { subcommand ->
@@ -226,8 +215,61 @@ internal class CommandReflector(
             }
         }
     }
+}
 
-    fun validate(signatures: List<CommandSignatureFromKFunction>) {
+@OptIn(ExperimentalCommandDescriptors::class)
+internal interface SubCommandReflectible {
+    @Throws(IllegalCommandDeclarationException::class)
+    fun findSubCommands(): List<CommandSignatureFromKFunction>
+    fun validate(signatures: List<CommandSignatureFromKFunction>)
+}
+
+@OptIn(ExperimentalCommandDescriptors::class)
+internal class SubCommandReflector<T: Any>(
+    val owner: T,
+    private val annotationResolver: SubCommandAnnotationResolver<T>,
+) : SubCommandReflectible {
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline fun KFunction<*>.illegalDeclaration(
+        message: String,
+    ): Nothing {
+        throw IllegalCommandDeclarationException(owner, this, message)
+    }
+
+    private fun KProperty<*>.isSubCommandProviderProperty(): Boolean = annotationResolver.hasPropertyAnnotation(owner, this)
+    private fun KFunction<*>.isSubCommandFunction(): Boolean = annotationResolver.hasAnnotation(owner, this)
+    private fun KFunction<*>.checkExtensionReceiver() {
+        this.extensionReceiverParameter?.let { receiver ->
+            val classifier = receiver.type.classifierAsKClassOrNull()
+            if (classifier != null) {
+                if (!classifier.isSubclassOf(CommandSender::class) && !classifier.isSubclassOf(CommandContext::class)) {
+                    illegalDeclaration("Extension receiver parameter type is not subclass of CommandSender nor CommandContext.")
+                }
+            }
+        }
+    }
+
+    private fun KFunction<*>.checkNames() {
+        val names = annotationResolver.getSubCommandNames(owner, this)
+        for (name in names) {
+            ILLEGAL_SUB_NAME_CHARS.find { it in name }?.let {
+                illegalDeclaration("'$it' is forbidden in command name.")
+            }
+        }
+    }
+
+    private fun KFunction<*>.checkModifiers() {
+        if (isInline) illegalDeclaration("Command function cannot be inline")
+        if (visibility == KVisibility.PRIVATE) illegalDeclaration("Command function must be accessible from Mirai Console, that is, effectively public.")
+        if (this.hasAnnotation<JvmStatic>()) illegalDeclaration("Command function must not be static.")
+
+        // should we allow abstract?
+
+        // if (isAbstract) illegalDeclaration("Command function cannot be abstract")
+    }
+
+    override fun validate(signatures: List<CommandSignatureFromKFunction>) {
 
         data class ErasedParameterInfo(
             val index: Int,
@@ -263,19 +305,20 @@ internal class CommandReflector(
             value.size > 1
         } ?: return
 
-        throw CommandDeclarationClashException(command, clashes.value.map { it.first })
+
+        throw SubcommandDeclarationClashException(owner, clashes.value.map { it.first })
     }
 
     @Throws(IllegalCommandDeclarationException::class)
-    fun findSubCommands(): List<CommandSignatureFromKFunction> {
-        val fromMemberFunctions = command::class.functions // exclude static later
+    override fun findSubCommands(): List<CommandSignatureFromKFunction> {
+        val fromMemberFunctions = owner::class.functions // exclude static later
             .asSequence()
             .filter { it.isSubCommandFunction() }
             .onEach { it.checkExtensionReceiver() }
             .onEach { it.checkModifiers() }
             .onEach { it.checkNames() }
             .flatMap { function ->
-                val names = annotationResolver.getSubCommandNames(command, function)
+                val names = annotationResolver.getSubCommandNames(owner, function)
                 if (names.isEmpty()) sequenceOf(createMapEntry(null, function))
                 else names.associateWith { function }.asSequence()
             }
@@ -319,11 +362,11 @@ internal class CommandReflector(
 
                     val instanceParameter = function.instanceParameter
                     if (instanceParameter != null) {
-                        check(instanceParameter.type.classifierAsKClass().isInstance(command)) {
+                        check(instanceParameter.type.classifierAsKClass().isInstance(owner)) {
                             "Bad command call resolved. " +
-                                    "Function expects instance parameter ${instanceParameter.type} whereas actual instance is ${command::class}."
+                                    "Function expects instance parameter ${instanceParameter.type} whereas actual instance is ${owner::class}."
                         }
-                        args[instanceParameter] = command
+                        args[instanceParameter] = owner
                     }
 
                     if (receiverParameter != null) {
@@ -351,14 +394,14 @@ internal class CommandReflector(
                 }
             }.toList()
 
-        val fromMemberProperties = command::class.declaredMemberProperties
+        val fromMemberProperties = owner::class.declaredMemberProperties
             .asSequence()
-            .filter { it.isSubCommandProperty() }
-            .map { it.getter.call(command) }
-            .filter { it is CompositeCommand }
+            .filter { it.isSubCommandProviderProperty() }
+            .map { it.getter.call(owner) }
+            .filter { it is SubCommandGroup }
             .flatMap { property ->
-                property as CompositeCommand
-                property.overloads
+                property as SubCommandGroup
+                property.provideOverloads
             }.toList()
 
         val list: MutableList<CommandSignatureFromKFunction> = ArrayList()
@@ -409,5 +452,5 @@ internal class CommandReflector(
     }
 
     private fun KParameter.nameForCommandParameter(): String? =
-        annotationResolver.getAnnotatedName(command, this) ?: this.name
+        annotationResolver.getAnnotatedName(owner, this) ?: this.name
 }

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -82,7 +82,7 @@ internal object CompositeCommandSubCommandAnnotationResolver :
     override fun getDescription(ownerCommand: Command, function: KFunction<*>): String? =
         function.findAnnotation<CompositeCommand.Description>()?.value
 
-    override fun hasPropertyAnnotation(command: Command, kProperty: KProperty<*>): Boolean =
+    override fun isCombinedCommand(command: Command, kProperty: KProperty<*>): Boolean =
         kProperty.hasAnnotation<CompositeCommand.CombinedCommand>()
 
 }

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -67,56 +67,75 @@ internal fun Any.flattenCommandComponents(): MessageChain = buildMessageChain {
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object CompositeCommandSubCommandAnnotationResolver :
     SubCommandAnnotationResolver<Command> {
-    override fun hasAnnotation(ownerCommand: Command, function: KFunction<*>) =
-        function.hasAnnotation<CompositeCommand.SubCommand>()
+    override fun isDeclaredSubCommand(ownerCommand: Command, function: KFunction<*>) =
+        function.hasAnnotation<SubCommandGroup.SubCommand>()
 
-    override fun getSubCommandNames(ownerCommand: Command, function: KFunction<*>): Array<out String> {
-        val annotated = function.findAnnotation<CompositeCommand.SubCommand>()!!.value
+    override fun getDeclaredSubCommandNames(ownerCommand: Command, function: KFunction<*>): Array<out String> {
+        val annotated = function.findAnnotation<SubCommandGroup.SubCommand>()!!.value
         return if (annotated.isEmpty()) arrayOf(function.name)
         else annotated
     }
 
     override fun getAnnotatedName(ownerCommand: Command, parameter: KParameter): String? =
-        parameter.findAnnotation<CompositeCommand.Name>()?.value
+        parameter.findAnnotation<SubCommandGroup.Name>()?.value
 
     override fun getDescription(ownerCommand: Command, function: KFunction<*>): String? =
-        function.findAnnotation<CompositeCommand.Description>()?.value
+        function.findAnnotation<SubCommandGroup.Description>()?.value
 
-    override fun isCombinedCommand(command: Command, kProperty: KProperty<*>): Boolean =
-        kProperty.hasAnnotation<CompositeCommand.CombinedCommand>()
+    override fun isCombinedSubCommands(command: Command, kProperty: KProperty<*>): Boolean =
+        kProperty.hasAnnotation<SubCommandGroup.FlattenSubCommands>() || kProperty.hasAnnotation<SubCommandGroup.SubCommand>()
 
+    override fun getCombinedAdditionNames(command: Command, kProperty: KProperty<*>): Array<out String> {
+        return if (kProperty.hasAnnotation<SubCommandGroup.FlattenSubCommands>()) {
+            emptyArray()
+        } else {
+            val annotated = kProperty.findAnnotation<SubCommandGroup.SubCommand>()!!.value
+            if (annotated.isEmpty()) arrayOf(kProperty.name)
+            else annotated
+        }
+    }
 }
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object GroupedCommandSubCommandAnnotationResolver :
     SubCommandAnnotationResolver<Any> {
-    override fun hasAnnotation(ownerCommand: Any, function: KFunction<*>) =
-        function.hasAnnotation<AbstractSubCommandGroup.AnotherSubCommand>()
+    override fun isDeclaredSubCommand(ownerCommand: Any, function: KFunction<*>) =
+        function.hasAnnotation<SubCommandGroup.SubCommand>()
 
-    override fun getSubCommandNames(ownerCommand: Any, function: KFunction<*>): Array<out String> {
-        val annotated = function.findAnnotation<AbstractSubCommandGroup.AnotherSubCommand>()!!.value
+    override fun getDeclaredSubCommandNames(ownerCommand: Any, function: KFunction<*>): Array<out String> {
+        val annotated = function.findAnnotation<SubCommandGroup.SubCommand>()!!.value
         return if (annotated.isEmpty()) arrayOf(function.name)
         else annotated
     }
 
     override fun getAnnotatedName(ownerCommand: Any, parameter: KParameter): String? =
-        parameter.findAnnotation<AbstractSubCommandGroup.AnotherName>()?.value
+        parameter.findAnnotation<SubCommandGroup.Name>()?.value
 
     override fun getDescription(ownerCommand: Any, function: KFunction<*>): String? =
-        function.findAnnotation<AbstractSubCommandGroup.AnotherDescription>()?.value
+        function.findAnnotation<SubCommandGroup.Description>()?.value
 
-    override fun isCombinedCommand(command: Any, kProperty: KProperty<*>): Boolean =
-        kProperty.hasAnnotation<AbstractSubCommandGroup.AnotherCombinedCommand>()
+    override fun isCombinedSubCommands(command: Any, kProperty: KProperty<*>): Boolean =
+        kProperty.hasAnnotation<SubCommandGroup.FlattenSubCommands>() || kProperty.hasAnnotation<SubCommandGroup.SubCommand>()
+
+    override fun getCombinedAdditionNames(command: Any, kProperty: KProperty<*>): Array<out String> {
+        return if (kProperty.hasAnnotation<SubCommandGroup.FlattenSubCommands>()) {
+            emptyArray()
+        } else {
+            val annotated = kProperty.findAnnotation<SubCommandGroup.SubCommand>()!!.value
+            if (annotated.isEmpty()) arrayOf(kProperty.name)
+            else annotated
+        }
+    }
 
 }
 
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 internal object SimpleCommandSubCommandAnnotationResolver :
     SubCommandAnnotationResolver<Command> {
-    override fun hasAnnotation(ownerCommand: Command, function: KFunction<*>) =
+    override fun isDeclaredSubCommand(ownerCommand: Command, function: KFunction<*>) =
         function.hasAnnotation<SimpleCommand.Handler>()
 
-    override fun getSubCommandNames(ownerCommand: Command, function: KFunction<*>): Array<out String> =
+    override fun getDeclaredSubCommandNames(ownerCommand: Command, function: KFunction<*>): Array<out String> =
         emptyArray()
 
     override fun getAnnotatedName(ownerCommand: Command, parameter: KParameter): String? =
@@ -125,15 +144,20 @@ internal object SimpleCommandSubCommandAnnotationResolver :
     override fun getDescription(ownerCommand: Command, function: KFunction<*>): String =
         ownerCommand.description
 
-    override fun isCombinedCommand(command: Command, kProperty: KProperty<*>): Boolean = false
+    override fun isCombinedSubCommands(command: Command, kProperty: KProperty<*>): Boolean = false
+
+    override fun getCombinedAdditionNames(command: Command, kProperty: KProperty<*>): Array<out String> =
+        emptyArray()
+
 }
 
 internal interface SubCommandAnnotationResolver<T> {
-    fun hasAnnotation(ownerCommand: T, function: KFunction<*>): Boolean
-    fun getSubCommandNames(ownerCommand: T, function: KFunction<*>): Array<out String>
+    fun isDeclaredSubCommand(ownerCommand: T, function: KFunction<*>): Boolean
+    fun getDeclaredSubCommandNames(ownerCommand: T, function: KFunction<*>): Array<out String>
     fun getAnnotatedName(ownerCommand: T, parameter: KParameter): String?
     fun getDescription(ownerCommand: T, function: KFunction<*>): String?
-    fun isCombinedCommand(command: T, kProperty: KProperty<*>): Boolean
+    fun isCombinedSubCommands(command: T, kProperty: KProperty<*>): Boolean
+    fun getCombinedAdditionNames(command: T, kProperty: KProperty<*>): Array<out String>
 }
 
 @ConsoleExperimentalApi
@@ -232,8 +256,9 @@ internal class SubCommandReflector<T: Any>(
         throw IllegalCommandDeclarationException(owner, this, message)
     }
 
-    private fun KProperty<*>.isSubCommandProviderProperty(): Boolean = annotationResolver.isCombinedCommand(owner, this)
-    private fun KFunction<*>.isSubCommandFunction(): Boolean = annotationResolver.hasAnnotation(owner, this)
+    private fun KProperty<*>.isSubCommandProviderProperty(): Boolean = annotationResolver.isCombinedSubCommands(owner, this)
+    private fun KFunction<*>.isSubCommandFunction(): Boolean = annotationResolver.isDeclaredSubCommand(owner, this)
+    private fun KProperty<*>.getCombinedAdditionNames(): Array<out String> = annotationResolver.getCombinedAdditionNames(owner, this)
     private fun KFunction<*>.checkExtensionReceiver() {
         this.extensionReceiverParameter?.let { receiver ->
             val classifier = receiver.type.classifierAsKClassOrNull()
@@ -246,7 +271,7 @@ internal class SubCommandReflector<T: Any>(
     }
 
     private fun KFunction<*>.checkNames() {
-        val names = annotationResolver.getSubCommandNames(owner, this)
+        val names = annotationResolver.getDeclaredSubCommandNames(owner, this)
         for (name in names) {
             ILLEGAL_SUB_NAME_CHARS.find { it in name }?.let {
                 illegalDeclaration("'$it' is forbidden in command name.")
@@ -304,6 +329,92 @@ internal class SubCommandReflector<T: Any>(
         throw SubcommandDeclarationClashException(owner, clashes.value.map { it.first })
     }
 
+    private fun generateCommandSignatureFromKFunctionImplWithAdditionName(name: String?, origin: CommandSignatureFromKFunction): CommandSignatureFromKFunctionImpl {
+        val functionNameAsValueParameter =
+            name?.split(' ')?.mapIndexed { index, s -> createStringConstantParameterForName(index, s) }
+                .orEmpty()
+
+        return CommandSignatureFromKFunctionImpl(
+            receiverParameter = origin.receiverParameter,
+            valueParameters = functionNameAsValueParameter + origin.valueParameters,
+            originFunction = origin.originFunction
+        ) { call ->
+            origin.call(call)
+        }
+    }
+
+    private fun generateCommandSignatureFromKFunctionImplWithAdditionName(name: String?, function: KFunction<*>): CommandSignatureFromKFunctionImpl {
+        val functionNameAsValueParameter =
+            name?.split(' ')?.mapIndexed { index, s -> createStringConstantParameterForName(index, s) }
+                .orEmpty()
+
+        val valueParameters = function.valueParameters.toMutableList()
+        var receiverParameter = function.extensionReceiverParameter
+        if (receiverParameter == null && valueParameters.isNotEmpty()) {
+            val valueFirstParameter = valueParameters[0]
+            val classifier = valueFirstParameter.type.classifierAsKClassOrNull()
+            if (classifier != null && isAcceptableReceiverType(classifier)
+            ) {
+                receiverParameter = valueFirstParameter
+                valueParameters.removeAt(0)
+            }
+        }
+
+        val functionValueParameters =
+            valueParameters.associateBy { it.toUserDefinedCommandParameter() }
+
+        return CommandSignatureFromKFunctionImpl(
+            receiverParameter = receiverParameter?.toCommandReceiverParameter(),
+            valueParameters = functionNameAsValueParameter + functionValueParameters.keys,
+            originFunction = function
+        ) { call ->
+            val args = LinkedHashMap<KParameter, Any?>()
+
+            for ((commandParameter, value) in call.resolvedValueArguments) {
+                if (commandParameter is AbstractCommandValueParameter.StringConstant) {
+                    continue
+                }
+                val functionParameter =
+                    functionValueParameters[commandParameter]
+                        ?: error("Could not find a corresponding function parameter '${commandParameter.name}'")
+                args[functionParameter] = value
+            }
+
+            val instanceParameter = function.instanceParameter
+            if (instanceParameter != null) {
+                check(instanceParameter.type.classifierAsKClass().isInstance(owner)) {
+                    "Bad command call resolved. " +
+                            "Function expects instance parameter ${instanceParameter.type} whereas actual instance is ${owner::class}."
+                }
+                args[instanceParameter] = owner
+            }
+
+            if (receiverParameter != null) {
+
+                val receiverType = receiverParameter.type.classifierAsKClass()
+
+                if (receiverType.isSubclassOf(CommandContext::class)) {
+                    args[receiverParameter] = CommandContextImpl(call.caller, call.originalMessage)
+                } else {
+                    check(receiverType.isInstance(call.caller)) {
+                        "Bad command call resolved. " +
+                                "Function expects receiver parameter ${receiverParameter.type} whereas actual is ${call.caller::class}."
+                    }
+                    args[receiverParameter] = call.caller
+                }
+
+            }
+
+            // mirai-console#341
+            if (function.isSuspend) {
+                function.callSuspendBy(args)
+            } else {
+                runBIO { function.callBy(args) }
+            }
+        }
+    }
+
+
     @Throws(IllegalCommandDeclarationException::class)
     override fun findSubCommands(): List<CommandSignatureFromKFunction> {
         val fromMemberFunctions = owner::class.functions // exclude static later
@@ -313,91 +424,32 @@ internal class SubCommandReflector<T: Any>(
             .onEach { it.checkModifiers() }
             .onEach { it.checkNames() }
             .flatMap { function ->
-                val names = annotationResolver.getSubCommandNames(owner, function)
+                val names = annotationResolver.getDeclaredSubCommandNames(owner, function)
                 if (names.isEmpty()) sequenceOf(createMapEntry(null, function))
                 else names.associateWith { function }.asSequence()
             }
             .map { (name, function) ->
-
-                val functionNameAsValueParameter =
-                    name?.split(' ')?.mapIndexed { index, s -> createStringConstantParameterForName(index, s) }
-                        .orEmpty()
-
-                val valueParameters = function.valueParameters.toMutableList()
-                var receiverParameter = function.extensionReceiverParameter
-                if (receiverParameter == null && valueParameters.isNotEmpty()) {
-                    val valueFirstParameter = valueParameters[0]
-                    val classifier = valueFirstParameter.type.classifierAsKClassOrNull()
-                    if (classifier != null && isAcceptableReceiverType(classifier)
-                    ) {
-                        receiverParameter = valueFirstParameter
-                        valueParameters.removeAt(0)
-                    }
-                }
-
-                val functionValueParameters =
-                    valueParameters.associateBy { it.toUserDefinedCommandParameter() }
-
-                CommandSignatureFromKFunctionImpl(
-                    receiverParameter = receiverParameter?.toCommandReceiverParameter(),
-                    valueParameters = functionNameAsValueParameter + functionValueParameters.keys,
-                    originFunction = function
-                ) { call ->
-                    val args = LinkedHashMap<KParameter, Any?>()
-
-                    for ((commandParameter, value) in call.resolvedValueArguments) {
-                        if (commandParameter is AbstractCommandValueParameter.StringConstant) {
-                            continue
-                        }
-                        val functionParameter =
-                            functionValueParameters[commandParameter]
-                                ?: error("Could not find a corresponding function parameter '${commandParameter.name}'")
-                        args[functionParameter] = value
-                    }
-
-                    val instanceParameter = function.instanceParameter
-                    if (instanceParameter != null) {
-                        check(instanceParameter.type.classifierAsKClass().isInstance(owner)) {
-                            "Bad command call resolved. " +
-                                    "Function expects instance parameter ${instanceParameter.type} whereas actual instance is ${owner::class}."
-                        }
-                        args[instanceParameter] = owner
-                    }
-
-                    if (receiverParameter != null) {
-
-                        val receiverType = receiverParameter.type.classifierAsKClass()
-
-                        if (receiverType.isSubclassOf(CommandContext::class)) {
-                            args[receiverParameter] = CommandContextImpl(call.caller, call.originalMessage)
-                        } else {
-                            check(receiverType.isInstance(call.caller)) {
-                                "Bad command call resolved. " +
-                                        "Function expects receiver parameter ${receiverParameter.type} whereas actual is ${call.caller::class}."
-                            }
-                            args[receiverParameter] = call.caller
-                        }
-
-                    }
-
-                    // mirai-console#341
-                    if (function.isSuspend) {
-                        function.callSuspendBy(args)
-                    } else {
-                        runBIO { function.callBy(args) }
-                    }
-                }
+                generateCommandSignatureFromKFunctionImplWithAdditionName(name, function)
             }.toList()
 
         val fromMemberProperties = owner::class.declaredMemberProperties
             .asSequence()
             .filter { it.isSubCommandProviderProperty() }
-            .map { it.getter.call(owner) }
-            .filter { it is SubCommandGroup }
-            .flatMap { property ->
-                property as SubCommandGroup
-                property.overloads
-            }.toList()
+            .filter { it.getter.call(owner) is SubCommandGroup }
+            .flatMap {
+                val names = it.getCombinedAdditionNames()
+                val originOverloads = (it.getter.call(owner) as SubCommandGroup).overloads
+                if (names.isEmpty()) sequenceOf(createMapEntry(null, originOverloads))
+                else names.associateWith { originOverloads }.asSequence()
+            }
+            .map { (name, originOverloads) ->
+                originOverloads
+                    .map { originOverload ->
+                        generateCommandSignatureFromKFunctionImplWithAdditionName(name, originOverload)
+                    }
+            }
+            .flatten()
+            .toList()
 
         val list: MutableList<CommandSignatureFromKFunction> = ArrayList()
         list.addAll(fromMemberFunctions)

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -105,7 +105,7 @@ internal object GroupedCommandSubCommandAnnotationResolver :
     override fun getDescription(ownerCommand: Any, function: KFunction<*>): String? =
         function.findAnnotation<AbstractSubCommandGroup.AnotherDescription>()?.value
 
-    override fun hasPropertyAnnotation(command: Any, kProperty: KProperty<*>): Boolean =
+    override fun isCombinedCommand(command: Any, kProperty: KProperty<*>): Boolean =
         kProperty.hasAnnotation<AbstractSubCommandGroup.AnotherCombinedCommand>()
 
 }
@@ -125,7 +125,7 @@ internal object SimpleCommandSubCommandAnnotationResolver :
     override fun getDescription(ownerCommand: Command, function: KFunction<*>): String =
         ownerCommand.description
 
-    override fun hasPropertyAnnotation(command: Command, kProperty: KProperty<*>): Boolean = false
+    override fun isCombinedCommand(command: Command, kProperty: KProperty<*>): Boolean = false
 }
 
 internal interface SubCommandAnnotationResolver<T> {
@@ -133,7 +133,7 @@ internal interface SubCommandAnnotationResolver<T> {
     fun getSubCommandNames(ownerCommand: T, function: KFunction<*>): Array<out String>
     fun getAnnotatedName(ownerCommand: T, parameter: KParameter): String?
     fun getDescription(ownerCommand: T, function: KFunction<*>): String?
-    fun hasPropertyAnnotation(command: T, kProperty: KProperty<*>): Boolean
+    fun isCombinedCommand(command: T, kProperty: KProperty<*>): Boolean
 }
 
 @ConsoleExperimentalApi
@@ -232,7 +232,7 @@ internal class SubCommandReflector<T: Any>(
         throw IllegalCommandDeclarationException(owner, this, message)
     }
 
-    private fun KProperty<*>.isSubCommandProviderProperty(): Boolean = annotationResolver.hasPropertyAnnotation(owner, this)
+    private fun KProperty<*>.isSubCommandProviderProperty(): Boolean = annotationResolver.isCombinedCommand(owner, this)
     private fun KFunction<*>.isSubCommandFunction(): Boolean = annotationResolver.hasAnnotation(owner, this)
     private fun KFunction<*>.checkExtensionReceiver() {
         this.extensionReceiverParameter?.let { receiver ->
@@ -396,7 +396,7 @@ internal class SubCommandReflector<T: Any>(
             .filter { it is SubCommandGroup }
             .flatMap { property ->
                 property as SubCommandGroup
-                property.provideOverloads
+                property.overloads
             }.toList()
 
         val list: MutableList<CommandSignatureFromKFunction> = ArrayList()

--- a/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandReflector.kt
@@ -354,8 +354,10 @@ internal class CommandReflector(
         val fromMemberProperties = command::class.declaredMemberProperties
             .asSequence()
             .filter { it.isSubCommandProperty() }
-            .filterIsInstance(CompositeCommand::class.java)
+            .map { it.getter.call(command) }
+            .filter { it is CompositeCommand }
             .flatMap { property ->
+                property as CompositeCommand
                 property.overloadImpls
             }.toList()
 

--- a/mirai-console/backend/mirai-console/test/command/CommandContextTest.kt
+++ b/mirai-console/backend/mirai-console/test/command/CommandContextTest.kt
@@ -18,6 +18,7 @@ import net.mamoe.mirai.console.command.descriptor.ExperimentalCommandDescriptors
 import net.mamoe.mirai.console.command.java.JCompositeCommand
 import net.mamoe.mirai.console.command.java.JRawCommand
 import net.mamoe.mirai.console.command.java.JSimpleCommand
+import net.mamoe.mirai.console.command.SubCommandGroup.SubCommand
 import net.mamoe.mirai.console.internal.data.classifierAsKClass
 import net.mamoe.mirai.message.data.*
 import net.mamoe.mirai.utils.safeCast

--- a/mirai-console/backend/mirai-console/test/command/CommandContextTest.kt
+++ b/mirai-console/backend/mirai-console/test/command/CommandContextTest.kt
@@ -36,13 +36,39 @@ internal class CommandContextTest : AbstractCommandTest() {
         companion object Key : AbstractMessageKey<MyMetadata>({ it.safeCast() })
     }
 
-
     ///////////////////////////////////////////////////////////////////////////
     // RawCommand
     ///////////////////////////////////////////////////////////////////////////
 
     @TestFactory
     fun `can execute with sender`(): List<DynamicTest> {
+        val containerCompositeCommand = object : CompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : CompositeCommand(owner, "useless") {
+                @SubCommand
+                fun CommandContext.childSub(arg: MessageChain) {
+                    Testing.ok(arg)
+                }
+            }
+            @SubCommand
+            fun CommandContext.containerSub(arg: MessageChain) {
+                Testing.ok(arg)
+            }
+        }
+        val jContainerCompositeCommand = object : JCompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : JCompositeCommand(owner, "useless") {
+                @SubCommand
+                fun childSub(context: CommandContext, arg: MessageChain) {
+                    Testing.ok(arg)
+                }
+            }
+            @SubCommand
+            fun containerSub(context: CommandContext, arg: MessageChain) {
+                Testing.ok(arg)
+            }
+        }
+
         return listOf(
             object : RawCommand(owner, "test") {
                 override suspend fun CommandContext.onCommand(args: MessageChain) {
@@ -61,6 +87,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(arg)
                 }
             } to "/test sub foo",
+            containerCompositeCommand to "/test childSub foo",
+            containerCompositeCommand to "/test containerSub foo",
 
             object : JRawCommand(owner, "test") {
                 override fun onCommand(context: CommandContext, args: MessageChain) {
@@ -79,6 +107,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(arg)
                 }
             } to "/test sub foo",
+            jContainerCompositeCommand to "/test childSub foo",
+            jContainerCompositeCommand to "/test containerSub foo",
         ).map { (instance, cmd) ->
             DynamicTest.dynamicTest(instance::class.supertypes.first().classifierAsKClass().simpleName) {
                 runBlocking {
@@ -97,6 +127,33 @@ internal class CommandContextTest : AbstractCommandTest() {
 
     @TestFactory
     fun `RawCommand can execute and get original chain`(): List<DynamicTest> {
+        val containerCompositeCommand = object : CompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : CompositeCommand(owner, "useless") {
+                @SubCommand
+                fun CommandContext.childSub(arg: MessageChain) {
+                    Testing.ok(originalMessage)
+                }
+            }
+            @SubCommand
+            fun CommandContext.containerSub(arg: MessageChain) {
+                Testing.ok(originalMessage)
+            }
+        }
+        val jContainerCompositeCommand = object : JCompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : JCompositeCommand(owner, "useless") {
+                @SubCommand
+                fun childSub(context: CommandContext, arg: MessageChain) {
+                    Testing.ok(context.originalMessage)
+                }
+            }
+            @SubCommand
+            fun containerSub(context: CommandContext, arg: MessageChain) {
+                Testing.ok(context.originalMessage)
+            }
+        }
+
         return listOf(
             object : RawCommand(owner, "test") {
                 override suspend fun CommandContext.onCommand(args: MessageChain) {
@@ -115,6 +172,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(originalMessage)
                 }
             } to "/test sub foo",
+            containerCompositeCommand to "/test childSub foo",
+            containerCompositeCommand to "/test containerSub foo",
 
             object : JRawCommand(owner, "test") {
                 override fun onCommand(context: CommandContext, args: MessageChain) {
@@ -133,6 +192,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(context.originalMessage)
                 }
             } to "/test sub foo",
+            jContainerCompositeCommand to "/test childSub foo",
+            jContainerCompositeCommand to "/test containerSub foo",
         ).map { (instance, cmd) ->
             DynamicTest.dynamicTest(instance::class.supertypes.first().classifierAsKClass().simpleName) {
                 runBlocking {
@@ -151,6 +212,33 @@ internal class CommandContextTest : AbstractCommandTest() {
 
     @TestFactory
     fun `can execute and get metadata`(): List<DynamicTest> {
+        val containerCompositeCommand = object : CompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : CompositeCommand(owner, "useless") {
+                @SubCommand
+                fun CommandContext.childSub(arg: MessageChain) {
+                    Testing.ok(originalMessage[MyMetadata])
+                }
+            }
+            @SubCommand
+            fun CommandContext.containerSub(arg: MessageChain) {
+                Testing.ok(originalMessage[MyMetadata])
+            }
+        }
+        val jContainerCompositeCommand = object : JCompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : JCompositeCommand(owner, "useless") {
+                @SubCommand
+                fun childSub(context: CommandContext, arg: MessageChain) {
+                    Testing.ok(context.originalMessage[MyMetadata])
+                }
+            }
+            @SubCommand
+            fun containerSub(context: CommandContext, arg: MessageChain) {
+                Testing.ok(context.originalMessage[MyMetadata])
+            }
+        }
+
         val metadata = MyMetadata()
         return listOf(
             object : RawCommand(owner, "test") {
@@ -170,7 +258,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(originalMessage[MyMetadata])
                 }
             } to messageChainOf(PlainText("/test"), PlainText("sub"), metadata, PlainText("foo")),
-
+            containerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("childSub"), metadata, PlainText("foo")),
+            containerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("containerSub"), metadata, PlainText("foo")),
 
             object : JRawCommand(owner, "test") {
                 override fun onCommand(context: CommandContext, args: MessageChain) {
@@ -189,6 +278,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(context.originalMessage[MyMetadata])
                 }
             } to messageChainOf(PlainText("/test"), PlainText("sub"), metadata, PlainText("foo")),
+            jContainerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("childSub"), metadata, PlainText("foo")),
+            jContainerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("containerSub"), metadata, PlainText("foo")),
         ).map { (instance, cmd) ->
             DynamicTest.dynamicTest(instance::class.supertypes.first().classifierAsKClass().simpleName) {
                 runBlocking {
@@ -207,6 +298,33 @@ internal class CommandContextTest : AbstractCommandTest() {
 
     @TestFactory
     fun `RawCommand can execute and get chain including metadata`(): List<DynamicTest> {
+        val containerCompositeCommand = object : CompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : CompositeCommand(owner, "useless") {
+                @SubCommand
+                fun CommandContext.childSub(arg: MessageChain) {
+                    Testing.ok(originalMessage)
+                }
+            }
+            @SubCommand
+            fun CommandContext.containerSub(arg: MessageChain) {
+                Testing.ok(originalMessage)
+            }
+        }
+        val jContainerCompositeCommand = object : JCompositeCommand(owner, "test") {
+            @ChildCommand
+            val childFoo = object : JCompositeCommand(owner, "useless") {
+                @SubCommand
+                fun childSub(context: CommandContext, arg: MessageChain) {
+                    Testing.ok(context.originalMessage)
+                }
+            }
+            @SubCommand
+            fun containerSub(context: CommandContext, arg: MessageChain) {
+                Testing.ok(context.originalMessage)
+            }
+        }
+
         val metadata = MyMetadata()
         return listOf(
             object : RawCommand(owner, "test") {
@@ -226,6 +344,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(originalMessage)
                 }
             } to messageChainOf(PlainText("/test"), PlainText("sub"), metadata, PlainText("foo")),
+            containerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("childSub"), metadata, PlainText("foo")),
+            containerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("containerSub"), metadata, PlainText("foo")),
 
 
             object : JRawCommand(owner, "test") {
@@ -245,6 +365,8 @@ internal class CommandContextTest : AbstractCommandTest() {
                     Testing.ok(context.originalMessage)
                 }
             } to messageChainOf(PlainText("/test"), PlainText("sub"), metadata, PlainText("foo")),
+            jContainerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("childSub"), metadata, PlainText("foo")),
+            jContainerCompositeCommand to messageChainOf(PlainText("/test"), PlainText("containerSub"), metadata, PlainText("foo")),
         ).map { (instance, cmd) ->
             DynamicTest.dynamicTest(instance::class.supertypes.first().classifierAsKClass().simpleName) {
                 runBlocking {

--- a/mirai-console/backend/mirai-console/test/command/CommandValueArgumentContextTest.kt
+++ b/mirai-console/backend/mirai-console/test/command/CommandValueArgumentContextTest.kt
@@ -19,6 +19,7 @@ import net.mamoe.mirai.console.command.descriptor.ExperimentalCommandDescriptors
 import net.mamoe.mirai.console.command.descriptor.buildCommandArgumentContext
 import net.mamoe.mirai.console.command.java.JCompositeCommand
 import net.mamoe.mirai.console.command.java.JSimpleCommand
+import net.mamoe.mirai.console.command.SubCommandGroup.SubCommand
 import net.mamoe.mirai.console.internal.data.classifierAsKClass
 import net.mamoe.mirai.message.data.Image
 import net.mamoe.mirai.message.data.MessageContent

--- a/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
+++ b/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
@@ -24,6 +24,7 @@ import net.mamoe.mirai.console.command.CommandManager.INSTANCE.unregisterCommand
 import net.mamoe.mirai.console.command.descriptor.CommandValueArgumentParser
 import net.mamoe.mirai.console.command.descriptor.ExperimentalCommandDescriptors
 import net.mamoe.mirai.console.command.descriptor.buildCommandArgumentContext
+
 import net.mamoe.mirai.console.internal.command.CommandManagerImpl
 import net.mamoe.mirai.console.internal.command.flattenCommandComponents
 import net.mamoe.mirai.console.permission.PermissionService.Companion.permit
@@ -34,43 +35,43 @@ import java.time.temporal.TemporalAccessor
 import kotlin.reflect.KClass
 import kotlin.test.*
 
+import net.mamoe.mirai.console.command.SubCommandGroup.SubCommand
+import net.mamoe.mirai.console.command.SubCommandGroup.FlattenSubCommands
 
-
-
-class TestContainerCompositeCommand : CompositeCommand(
-    owner,
-    "testContainerComposite", "tsPC"
+class MyUnifiedCommand : CompositeCommand(
+    owner, "testMyUnifiedCommand", "tsMUC"
 ) {
-
-    class TopGroup : AbstractSubCommandGroup() {
-
-        class NestGroup : AbstractSubCommandGroup() {
-            @AnotherSubCommand
-            fun foo2(seconds: Int) {
-                Testing.ok(seconds)
-            }
-        }
-
-        @AnotherCombinedCommand
-        val provider: SubCommandGroup = NestGroup()
-
-        @AnotherSubCommand
-        fun foo1(seconds: Int) {
-            Testing.ok(seconds)
+    // 插件一个模块的部分功能
+    class ModuleAPart1 : AbstractSubCommandGroup() {
+        @SubCommand
+        fun function1(arg0: Int) {
+            Testing.ok(arg0)
         }
     }
 
-    @CombinedCommand
-    val provider: SubCommandGroup = TopGroup()
-
-    @SubCommand
-    fun foo0(seconds: Int) {
-        Testing.ok(seconds)
+    // 插件一个模块的另一部分功能
+    class ModuleAPart2 : AbstractSubCommandGroup() {
+        @SubCommand
+        fun function2(arg0: Int) {
+            Testing.ok(arg0)
+        }
     }
 
+    class ModuleACommandGroup: AbstractSubCommandGroup() {
+        @SubCommand // 与在函数上标注这个注解类似, 它会带 `part1` 这个名称前缀来注册指令. 需要执行  /base part1 function1
+        val part1 = ModuleAPart1()
+        @SubCommand("part1NewName") // 也可以使用 SubCommand 的参数来覆盖名称 /base part1NewName function1
+        val part1b = ModuleAPart1()
+        @FlattenSubCommands // 新增, 不带前缀注册指令, 执行 /base function2
+        val part2 = ModuleAPart2()
+    }
+
+    @FlattenSubCommands
+    val moduleA = ModuleACommandGroup()
+
     @SubCommand
-    fun containerBar(seconds: Int) {
-        Testing.ok(seconds)
+    fun about(arg0: Int) {
+        Testing.ok(arg0)
     }
 }
 
@@ -203,7 +204,7 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     private val simpleCommand by lazy { TestSimpleCommand() }
     private val rawCommand by lazy { TestRawCommand() }
     private val compositeCommand by lazy { TestCompositeCommand() }
-    private val containerCompositeCommand by lazy { TestContainerCompositeCommand() }
+    private val unifiedCompositeCommand by lazy { MyUnifiedCommand() }
 
     @BeforeTest
     fun grantPermission() {
@@ -542,15 +543,18 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
 
     @Test
     fun `container composite command executing`() = runBlocking {
-        containerCompositeCommand.withRegistration {
+        unifiedCompositeCommand.withRegistration {
             assertEquals(0, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "foo0 0"))
+                assertSuccess(unifiedCompositeCommand.execute(sender, "part1 function1 0"))
             })
-            assertEquals(1, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "foo1 1"))
+            assertEquals(0, withTesting {
+                assertSuccess(unifiedCompositeCommand.execute(sender, "part1NewName function1 0"))
             })
-            assertEquals(2, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "foo2 2"))
+            assertEquals(0, withTesting {
+                assertSuccess(unifiedCompositeCommand.execute(sender, "function2 0"))
+            })
+            assertEquals(0, withTesting {
+                assertSuccess(unifiedCompositeCommand.execute(sender, "about 0"))
             })
         }
     }

--- a/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
+++ b/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
@@ -34,9 +34,9 @@ import java.time.temporal.TemporalAccessor
 import kotlin.reflect.KClass
 import kotlin.test.*
 
-class TestParentCompositeCommand : CompositeCommand(
+class TestContainerCompositeCommand : CompositeCommand(
     owner,
-    "testParentComposite", "tsPC"
+    "testContainerComposite", "tsPC"
 ) {
 
     class ChildCompositeCommand1 : CompositeCommand(owner, "useless") {
@@ -54,18 +54,18 @@ class TestParentCompositeCommand : CompositeCommand(
     }
 
     @ChildCommand
-    val child1: ChildCompositeCommand1  = ChildCompositeCommand1();
+    val child1: ChildCompositeCommand1  = ChildCompositeCommand1()
 
     @ChildCommand
-    val child2: ChildCompositeCommand2 = ChildCompositeCommand2();
+    val child2: ChildCompositeCommand2 = ChildCompositeCommand2()
 
     @SubCommand
-    fun parentFoo(seconds: Int) {
+    fun containerFoo(seconds: Int) {
         Testing.ok(seconds)
     }
 
     @SubCommand
-    fun parentBar(seconds: Int) {
+    fun containerBar(seconds: Int) {
         Testing.ok(seconds)
     }
 }
@@ -199,7 +199,7 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     private val simpleCommand by lazy { TestSimpleCommand() }
     private val rawCommand by lazy { TestRawCommand() }
     private val compositeCommand by lazy { TestCompositeCommand() }
-    private val parentCompositeCommand by lazy { TestParentCompositeCommand() }
+    private val containerCompositeCommand by lazy { TestContainerCompositeCommand() }
 
     @BeforeTest
     fun grantPermission() {
@@ -537,19 +537,19 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     }
 
     @Test
-    fun `parent composite command executing`() = runBlocking {
-        parentCompositeCommand.withRegistration {
+    fun `container composite command executing`() = runBlocking {
+        containerCompositeCommand.withRegistration {
             assertEquals(1, withTesting {
-                assertSuccess(parentCompositeCommand.execute(sender, "parentFoo 1"))
+                assertSuccess(containerCompositeCommand.execute(sender, "containerFoo 1"))
             })
             assertEquals(1, withTesting {
-                assertSuccess(parentCompositeCommand.execute(sender, "parentBar 1"))
+                assertSuccess(containerCompositeCommand.execute(sender, "containerBar 1"))
             })
             assertEquals(2, withTesting {
-                assertSuccess(parentCompositeCommand.execute(sender, "foo 2"))
+                assertSuccess(containerCompositeCommand.execute(sender, "foo 2"))
             })
             assertEquals(2, withTesting {
-                assertSuccess(parentCompositeCommand.execute(sender, "bar 2"))
+                assertSuccess(containerCompositeCommand.execute(sender, "bar 2"))
             })
         }
     }

--- a/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
+++ b/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
@@ -39,20 +39,14 @@ class TestParentCompositeCommand : CompositeCommand(
     "testParentComposite", "tsPC"
 ) {
 
-    class ChildCompositeCommand1 : CompositeCommand(
-        owner,
-        "testChildComposite1", "tsCC1"
-    ) {
+    class ChildCompositeCommand1 : CompositeCommand(owner, "useless") {
         @SubCommand
         fun foo(seconds: Int) {
             Testing.ok(seconds)
         }
     }
 
-    class ChildCompositeCommand2 : CompositeCommand(
-        owner,
-        "testChildComposite2", "tsCC2"
-    ) {
+    class ChildCompositeCommand2 : CompositeCommand(owner, "useless") {
         @SubCommand
         fun bar(seconds: Int) {
             Testing.ok(seconds)
@@ -546,24 +540,13 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     fun `parent composite command executing`() = runBlocking {
         parentCompositeCommand.withRegistration {
             assertEquals(1, withTesting {
-                assertSuccess(
-                    parentCompositeCommand.execute(sender, "parentFoo 1")
-                )
+                assertSuccess(parentCompositeCommand.execute(sender, "parentFoo 1"))
             })
             assertEquals(1, withTesting {
-                assertSuccess(
-                    parentCompositeCommand.execute(sender, "parentBar 1")
-                )
+                assertSuccess(parentCompositeCommand.execute(sender, "parentBar 1"))
             })
-            assertEquals(1, withTesting {
-                assertSuccess(
-                    parentCompositeCommand.execute(sender, "foo 1")
-                )
-            })
-            assertEquals(1, withTesting {
-                assertSuccess(
-                    parentCompositeCommand.execute(sender, "foo 1")
-                )
+            assertEquals(2, withTesting {
+                assertSuccess(parentCompositeCommand.execute(sender, "foo 2"))
             })
             assertEquals(2, withTesting {
                 assertSuccess(parentCompositeCommand.execute(sender, "bar 2"))

--- a/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
+++ b/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
@@ -34,33 +34,37 @@ import java.time.temporal.TemporalAccessor
 import kotlin.reflect.KClass
 import kotlin.test.*
 
+
+
+
 class TestContainerCompositeCommand : CompositeCommand(
     owner,
     "testContainerComposite", "tsPC"
 ) {
 
-    class ChildCompositeCommand1 : CompositeCommand(owner, "useless") {
-        @SubCommand
-        fun foo(seconds: Int) {
+    class TopGroup : AbstractSubCommandGroup() {
+
+        class NestGroup : AbstractSubCommandGroup() {
+            @AnotherSubCommand
+            fun foo2(seconds: Int) {
+                Testing.ok(seconds)
+            }
+        }
+
+        @AnotherCombinedCommand
+        val provider: SubCommandGroup = NestGroup()
+
+        @AnotherSubCommand
+        fun foo1(seconds: Int) {
             Testing.ok(seconds)
         }
     }
 
-    class ChildCompositeCommand2 : CompositeCommand(owner, "useless") {
-        @SubCommand
-        fun bar(seconds: Int) {
-            Testing.ok(seconds)
-        }
-    }
-
-    @ChildCommand
-    val child1: ChildCompositeCommand1  = ChildCompositeCommand1()
-
-    @ChildCommand
-    val child2: ChildCompositeCommand2 = ChildCompositeCommand2()
+    @CombinedCommand
+    val provider: SubCommandGroup = TopGroup()
 
     @SubCommand
-    fun containerFoo(seconds: Int) {
+    fun foo0(seconds: Int) {
         Testing.ok(seconds)
     }
 
@@ -539,17 +543,14 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     @Test
     fun `container composite command executing`() = runBlocking {
         containerCompositeCommand.withRegistration {
-            assertEquals(1, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "containerFoo 1"))
+            assertEquals(0, withTesting {
+                assertSuccess(containerCompositeCommand.execute(sender, "foo0 0"))
             })
             assertEquals(1, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "containerBar 1"))
+                assertSuccess(containerCompositeCommand.execute(sender, "foo1 1"))
             })
             assertEquals(2, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "foo 2"))
-            })
-            assertEquals(2, withTesting {
-                assertSuccess(containerCompositeCommand.execute(sender, "bar 2"))
+                assertSuccess(containerCompositeCommand.execute(sender, "foo2 2"))
             })
         }
     }

--- a/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
+++ b/mirai-console/backend/mirai-console/test/command/InstanceTestCommand.kt
@@ -34,6 +34,48 @@ import java.time.temporal.TemporalAccessor
 import kotlin.reflect.KClass
 import kotlin.test.*
 
+class TestParentCompositeCommand : CompositeCommand(
+    owner,
+    "testParentComposite", "tsPC"
+) {
+
+    class ChildCompositeCommand1 : CompositeCommand(
+        owner,
+        "testChildComposite1", "tsCC1"
+    ) {
+        @SubCommand
+        fun foo(seconds: Int) {
+            Testing.ok(seconds)
+        }
+    }
+
+    class ChildCompositeCommand2 : CompositeCommand(
+        owner,
+        "testChildComposite2", "tsCC2"
+    ) {
+        @SubCommand
+        fun bar(seconds: Int) {
+            Testing.ok(seconds)
+        }
+    }
+
+    @ChildCommand
+    val child1: ChildCompositeCommand1  = ChildCompositeCommand1();
+
+    @ChildCommand
+    val child2: ChildCompositeCommand2 = ChildCompositeCommand2();
+
+    @SubCommand
+    fun parentFoo(seconds: Int) {
+        Testing.ok(seconds)
+    }
+
+    @SubCommand
+    fun parentBar(seconds: Int) {
+        Testing.ok(seconds)
+    }
+}
+
 class TestCompositeCommand : CompositeCommand(
     owner,
     "testComposite", "tsC"
@@ -163,6 +205,7 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
     private val simpleCommand by lazy { TestSimpleCommand() }
     private val rawCommand by lazy { TestRawCommand() }
     private val compositeCommand by lazy { TestCompositeCommand() }
+    private val parentCompositeCommand by lazy { TestParentCompositeCommand() }
 
     @BeforeTest
     fun grantPermission() {
@@ -495,6 +538,35 @@ internal class InstanceTestCommand : AbstractConsoleInstanceTest() {
         compositeCommand.withRegistration {
             assertEquals(1, withTesting {
                 assertSuccess(compositeCommand.execute(sender, "mute 1"))
+            })
+        }
+    }
+
+    @Test
+    fun `parent composite command executing`() = runBlocking {
+        parentCompositeCommand.withRegistration {
+            assertEquals(1, withTesting {
+                assertSuccess(
+                    parentCompositeCommand.execute(sender, "parentFoo 1")
+                )
+            })
+            assertEquals(1, withTesting {
+                assertSuccess(
+                    parentCompositeCommand.execute(sender, "parentBar 1")
+                )
+            })
+            assertEquals(1, withTesting {
+                assertSuccess(
+                    parentCompositeCommand.execute(sender, "foo 1")
+                )
+            })
+            assertEquals(1, withTesting {
+                assertSuccess(
+                    parentCompositeCommand.execute(sender, "foo 1")
+                )
+            })
+            assertEquals(2, withTesting {
+                assertSuccess(parentCompositeCommand.execute(sender, "bar 2"))
             })
         }
     }


### PR DESCRIPTION
效果：
- 对于CompositeCommand，其被`@ChildCommad`注解的CompositeCommand子类成员中的所有子指令，也会成为他的子指令。（见InstanceTestCommand.kt变动）
- 实际插件开发中可用于“将多个CompositeCommand注册注册到同一个主指令名” (will close #1804 )

改动说明：
- 新增注解`@ChildCommad`。~~也可以考虑继续使用`@SubCommad`？以及child的命名可能会引起歧义想到继承关系~~
- 需要将数个CommandReflector的方法改为返回接口类而不是实现类
