### PR TITLE
feat: login use auto login account configuration

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/command/builtin/LoginCommandImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/builtin/LoginCommandImpl.kt
@@ -45,7 +45,30 @@ internal open class LoginCommandImpl : SimpleCommand(
         protocol: BotConfiguration.MiraiProtocol? = null,
     ) {
         fun BotConfiguration.setup(protocol: BotConfiguration.MiraiProtocol?): BotConfiguration {
-            if (protocol != null) this.protocol = protocol
+            val config = DataScope.get<AutoLoginConfig>()
+            val account = config.accounts.firstOrNull { it.account == id.toString() }
+            if (account != null) {
+                account.configuration[AutoLoginConfig.Account.ConfigurationKey.protocol]?.let { protocol ->
+                    try {
+                        this.protocol = BotConfiguration.MiraiProtocol.valueOf(protocol.toString())
+                    } catch (_: Throwable) {
+                        //
+                    }
+                }
+                account.configuration[AutoLoginConfig.Account.ConfigurationKey.heartbeatStrategy]?.let { heartStrate ->
+                    try {
+                        this.heartbeatStrategy = BotConfiguration.HeartbeatStrategy.valueOf(heartStrate.toString())
+                    } catch (_: Throwable) {
+                        //
+                    }
+                }
+                account.configuration[AutoLoginConfig.Account.ConfigurationKey.device]?.let { device ->
+                    fileBasedDeviceInfo(device.toString())
+                }
+            }
+            if (protocol != null) {
+                this.protocol = protocol
+            }
             return this
         }
 


### PR DESCRIPTION
在指令 `login` 中载入`autoLogin` 的 `account configuration` 配置  

主要目的是 解决 `login` 的 `password` 参数 为空时会使用 `autoLogin` 的 配置，但 `protocol` 不会，和直觉不符
