### PR TITLE
feat: load SPI Service in jvm plugin

### DIFF
--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -2236,6 +2236,8 @@ public abstract class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPlugin : net
 	public final fun reloadPluginData (Lnet/mamoe/mirai/console/data/PluginData;)V
 	public final fun savePluginConfig (Lnet/mamoe/mirai/console/data/PluginConfig;)V
 	public final fun savePluginData (Lnet/mamoe/mirai/console/data/PluginData;)V
+	protected final fun services (Ljava/lang/Class;)Lkotlin/Lazy;
+	protected final synthetic fun services (Lkotlin/reflect/KClass;)Lkotlin/Lazy;
 }
 
 public final class net/mamoe/mirai/console/plugin/jvm/AbstractJvmPluginKt {

--- a/mirai-console/backend/mirai-console/src/plugin/jvm/AbstractJvmPlugin.kt
+++ b/mirai-console/backend/mirai-console/src/plugin/jvm/AbstractJvmPlugin.kt
@@ -99,6 +99,9 @@ public abstract class AbstractJvmPlugin @JvmOverloads constructor(
     /**
      * 获取 指定类的 SPI Service
      *
+     * 为了兼容 Kotlin object 单例类，此方法没有直接使用 java 原生的 API,
+     * 而是 手动读取 `META-INF/services/` 的内容, 并尝试构造或获取实例
+     *
      * 注: 仅包括当前插件 JAR 的 Service
      */
     @JvmSynthetic
@@ -118,12 +121,18 @@ public abstract class AbstractJvmPlugin @JvmOverloads constructor(
     /**
      * 获取 指定类的 SPI Service
      *
+     * 为了兼容 Kotlin object 单例类，此方法没有直接使用 java 原生的 API,
+     * 而是 手动读取 `META-INF/services/` 的内容, 并尝试构造或获取实例
+     *
      * 注: 仅包括当前插件 JAR 的 Service
      */
     protected fun <T: Any> services(clazz: Class<out T>): Lazy<List<T>> = services(kClass = clazz.kotlin)
 
     /**
      * 获取 指定类的 SPI Service
+     *
+     * 为了兼容 Kotlin object 单例类，此方法没有直接使用 java 原生的 API,
+     * 而是 手动读取 `META-INF/services/` 的内容, 并尝试构造或获取实例
      *
      * 注: 仅包括当前插件 JAR 的 Service
      */


### PR DESCRIPTION
添加从 插件 jar 中 加载 SPI Service 的API

用来实现统一加载 Command 或者 PluginConfig 之类服务的效果
```
private val commands: List<Command> by services()

override fun onEnable() {
    for (command in commands) command.register()
}

override fun onDisable() {
    for (command in commands) command.unregister()
}
```
