### PR TITLE
fix: unwarp InvocationTargetException in command stack trace

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/command/CommandManagerImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/command/CommandManagerImpl.kt
@@ -28,6 +28,7 @@ import net.mamoe.mirai.message.data.Message
 import net.mamoe.mirai.message.data.toMessageChain
 import net.mamoe.mirai.utils.MiraiLogger
 import net.mamoe.mirai.utils.childScope
+import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.coroutines.CoroutineContext
 
@@ -168,6 +169,12 @@ internal suspend fun executeCommandImpl(
         CommandExecuteResult.Success(resolved.callee, call, resolved)
     } catch (e: CommandArgumentParserException) {
         CommandExecuteResult.IllegalArgument(e, resolved.callee, call, resolved)
+    } catch (e: InvocationTargetException) {
+        when (val target = e.cause) {
+            is CommandArgumentParserException -> CommandExecuteResult.IllegalArgument(target, resolved.callee, call, resolved)
+            null -> CommandExecuteResult.ExecutionFailed(e, resolved.callee, call, resolved)
+            else -> CommandExecuteResult.ExecutionFailed(target, resolved.callee, call, resolved)
+        }
     } catch (e: Throwable) {
         CommandExecuteResult.ExecutionFailed(e, resolved.callee, call, resolved)
     }


### PR DESCRIPTION
在指令的方法中 throw 往往会 套着一层 `InvocationTargetException`, 但一般不包含有用信息，还占用有效信息的空间

```
2022-09-26 09:39:40 E/console: java.lang.reflect.InvocationTargetException
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)
        at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Instance.call(CallerImpl.kt:113)
        at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108)
        at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:159)
        at kotlin.reflect.full.KCallables.callSuspendBy(KCallables.kt:74)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invokeSuspend(CommandReflector.kt:337)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invoke(CommandReflector.kt)
        at net.mamoe.mirai.console.internal.command.CommandReflector$findSubCommands$6$1.invoke(CommandReflector.kt)
        at net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunctionImpl.call$suspendImpl(CommandSignature.kt:88)
        at net.mamoe.mirai.console.command.descriptor.CommandSignatureFromKFunctionImpl.call(CommandSignature.kt)
        at net.mamoe.mirai.console.internal.command.CommandManagerImplKt.executeCommandImpl(CommandManagerImpl.kt:168)
        at net.mamoe.mirai.console.command.CommandManager.executeCommand$suspendImpl(CommandManager.kt:130)
        at net.mamoe.mirai.console.command.CommandManager.executeCommand(CommandManager.kt)
        at net.mamoe.mirai.console.command.CommandManager$INSTANCE.executeCommand(CommandManager.kt)
        at net.mamoe.mirai.console.terminal.ConsoleThreadKt$startupConsoleThread$3.invokeSuspend(ConsoleThread.kt:190)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
Caused by: java.lang.IllegalStateException: 词条数量不对
        at arknights-helper-2.0.0-dev-1.mirai2.jar//xyz.cssxsh.arknights.excel.GachaKt.recruit(Gacha.kt:32)
        at arknights-helper-2.0.0-dev-1.mirai2.jar//xyz.cssxsh.mirai.arknights.command.ArknightsRecruitCommand.handler(ArknightsRecruitCommand.kt:52)
        ... 25 more
```