### PR TITLE
[console] Update console logging system

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -61,7 +61,7 @@ object Versions {
 
     const val logback = "1.2.5"
     const val slf4j = "2.0.3"
-    const val log4j = "2.17.2"
+    const val log4j = "2.19.0"
     const val asm = "9.4"
     const val difflib = "1.3.0"
     const val netty = "4.1.63.Final"
@@ -230,7 +230,7 @@ const val `slf4j-simple` = "org.slf4j:slf4j-simple:" + Versions.slf4j
 
 const val `log4j-api` = "org.apache.logging.log4j:log4j-api:" + Versions.log4j
 const val `log4j-core` = "org.apache.logging.log4j:log4j-core:" + Versions.log4j
-const val `log4j-slf4j-impl` = "org.apache.logging.log4j:log4j-slf4j-impl:" + Versions.log4j
+const val `log4j-slf4j2-impl` = "org.apache.logging.log4j:log4j-slf4j2-impl:" + Versions.log4j
 const val `log4j-to-slf4j` = "org.apache.logging.log4j:log4j-to-slf4j:" + Versions.log4j
 
 val ATTRIBUTE_MIRAI_TARGET_PLATFORM: Attribute<String> = Attribute.of("mirai.target.platform", String::class.java)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -59,7 +59,7 @@ object Versions {
 
     const val shadow = "7.1.3-mirai-modified-SNAPSHOT"
 
-    const val logback = "1.2.5"
+    const val logback = "1.3.4"
     const val slf4j = "2.0.3"
     const val log4j = "2.19.0"
     const val asm = "9.4"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -60,7 +60,7 @@ object Versions {
     const val shadow = "7.1.3-mirai-modified-SNAPSHOT"
 
     const val logback = "1.2.5"
-    const val slf4j = "1.7.32"
+    const val slf4j = "2.0.3"
     const val log4j = "2.17.2"
     const val asm = "9.4"
     const val difflib = "1.3.0"

--- a/logging/mirai-logging-log4j2/build.gradle.kts
+++ b/logging/mirai-logging-log4j2/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api(project(":mirai-core-api"))
     api(`log4j-api`)
     api(`log4j-core`)
-    api(`log4j-slf4j-impl`)
+    api(`log4j-slf4j2-impl`)
 
 
     testImplementation(`slf4j-api`)

--- a/logging/mirai-logging-slf4j-logback/build.gradle.kts
+++ b/logging/mirai-logging-slf4j-logback/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api(project(":mirai-core-api"))
     api(project(":mirai-logging-slf4j")) // mirai -> slf4j
     implementation(project(":mirai-logging-log4j2")) {
-        exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+        exclude("org.apache.logging.log4j", "log4j-slf4j2-impl")
     } // mirai -> log4j2
     api(`slf4j-api`)
     api(`logback-classic`)

--- a/logging/mirai-logging-slf4j/build.gradle.kts
+++ b/logging/mirai-logging-slf4j/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
 dependencies {
     api(project(":mirai-core-api"))
     implementation(project(":mirai-logging-log4j2")) {
-        exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+        exclude("org.apache.logging.log4j", "log4j-slf4j2-impl")
     } // mirai -> log4j2
     implementation(`log4j-to-slf4j`) // log4j2 -> slf4j
     api(`slf4j-api`)

--- a/mirai-console/backend/mirai-console/build.gradle.kts
+++ b/mirai-console/backend/mirai-console/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     smartImplementation(`maven-resolver-impl`)
     smartImplementation(`maven-resolver-connector-basic`)
     smartImplementation(`maven-resolver-transport-http`)
+    smartImplementation(`slf4j-api`)
     smartApi(`kotlinx-coroutines-jdk8`)
 
     testApi(project(":mirai-core"))

--- a/mirai-console/backend/mirai-console/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/mirai-console/backend/mirai-console/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+net.mamoe.mirai.console.internal.logging.externalbind.slf4j.MiraiConsoleSLF4JService

--- a/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
+++ b/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
@@ -270,6 +270,9 @@ ___  ____           _   _____                       _
                 consoleDataScope.addAndReloadConfig(loggerController.loggerConfig)
             }
             consoleDataScope.reloadAll()
+            if (loggerController is LoggerControllerImpl) {
+                loggerController.onReload()
+            }
         }
 
         phase("initialize all plugins") {

--- a/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
+++ b/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
@@ -42,6 +42,7 @@ import net.mamoe.mirai.console.internal.extension.GlobalComponentStorage
 import net.mamoe.mirai.console.internal.extension.GlobalComponentStorageImpl
 import net.mamoe.mirai.console.internal.logging.LoggerControllerImpl
 import net.mamoe.mirai.console.internal.logging.MiraiConsoleLogger
+import net.mamoe.mirai.console.internal.logging.externalbind.slf4j.MiraiConsoleSLF4JAdapter
 import net.mamoe.mirai.console.internal.permission.BuiltInPermissionService
 import net.mamoe.mirai.console.internal.plugin.PluginManagerImpl
 import net.mamoe.mirai.console.internal.shutdown.ShutdownDaemon
@@ -276,6 +277,10 @@ ___  ____           _   _____                       _
             if (loggerController is LoggerControllerImpl) {
                 loggerController.onReload()
             }
+        }
+
+        phase("initialize logging bridges") {
+            MiraiConsoleSLF4JAdapter.doSlf4JInit()
         }
 
         phase("initialize all plugins") {

--- a/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
+++ b/mirai-console/backend/mirai-console/src/internal/MiraiConsoleImplementationBridge.kt
@@ -36,6 +36,7 @@ import net.mamoe.mirai.console.internal.data.builtins.AutoLoginConfig.Account.Co
 import net.mamoe.mirai.console.internal.data.builtins.AutoLoginConfig.Account.PasswordKind.MD5
 import net.mamoe.mirai.console.internal.data.builtins.AutoLoginConfig.Account.PasswordKind.PLAIN
 import net.mamoe.mirai.console.internal.data.builtins.DataScope
+import net.mamoe.mirai.console.internal.data.builtins.LoggerConfig
 import net.mamoe.mirai.console.internal.data.builtins.PluginDependenciesConfig
 import net.mamoe.mirai.console.internal.extension.GlobalComponentStorage
 import net.mamoe.mirai.console.internal.extension.GlobalComponentStorageImpl
@@ -268,6 +269,8 @@ ___  ____           _   _____                       _
             val loggerController = loggerController
             if (loggerController is LoggerControllerImpl) {
                 consoleDataScope.addAndReloadConfig(loggerController.loggerConfig)
+            } else {
+                consoleDataScope.addAndReloadConfig(LoggerConfig())
             }
             consoleDataScope.reloadAll()
             if (loggerController is LoggerControllerImpl) {

--- a/mirai-console/backend/mirai-console/src/internal/data/builtins/LoggerConfig.kt
+++ b/mirai-console/backend/mirai-console/src/internal/data/builtins/LoggerConfig.kt
@@ -9,6 +9,7 @@
 
 package net.mamoe.mirai.console.internal.data.builtins
 
+import kotlinx.serialization.Serializable
 import net.mamoe.mirai.console.ConsoleFrontEndImplementation
 import net.mamoe.mirai.console.data.ReadOnlyPluginConfig
 import net.mamoe.mirai.console.data.ValueDescription
@@ -40,4 +41,14 @@ public class LoggerConfig : ReadOnlyPluginConfig("Logger") {
         )
     )
 
+    @Serializable
+    public class Binding @MiraiExperimentalApi public constructor(
+    )
+
+    @ValueDescription(
+        """
+            是否启动外部日志框架桥接
+        """
+    )
+    public val binding: Binding by value { Binding() }
 }

--- a/mirai-console/backend/mirai-console/src/internal/data/builtins/LoggerConfig.kt
+++ b/mirai-console/backend/mirai-console/src/internal/data/builtins/LoggerConfig.kt
@@ -38,11 +38,14 @@ public class LoggerConfig : ReadOnlyPluginConfig("Logger") {
             "example.logger" to AbstractLoggerController.LogPriority.NONE,
             "console.debug" to AbstractLoggerController.LogPriority.NONE,
             "Bot" to AbstractLoggerController.LogPriority.ALL,
+            "org.eclipse.aether.internal" to AbstractLoggerController.LogPriority.INFO,
+            "org.apache.http.wire" to AbstractLoggerController.LogPriority.INFO,
         )
     )
 
     @Serializable
     public class Binding @MiraiExperimentalApi public constructor(
+        public val slf4j: Boolean = true,
     )
 
     @ValueDescription(

--- a/mirai-console/backend/mirai-console/src/internal/logging/LoggerControllerImpl.kt
+++ b/mirai-console/backend/mirai-console/src/internal/logging/LoggerControllerImpl.kt
@@ -18,6 +18,11 @@ internal class LoggerControllerImpl : AbstractLoggerController.PathBased() {
     internal val loggerConfig: LoggerConfig by lazy {
         LoggerConfig()
     }
+    override val isLoggerControlStateSupported: Boolean get() = true
+
+    internal fun onReload() {
+        this.loggerConfigUpdateTime++
+    }
 
     override fun findPriority(identity: String?): LogPriority? {
         return if (identity == null) {

--- a/mirai-console/backend/mirai-console/src/internal/logging/MiraiConsoleLogger.kt
+++ b/mirai-console/backend/mirai-console/src/internal/logging/MiraiConsoleLogger.kt
@@ -15,45 +15,47 @@ import net.mamoe.mirai.utils.MiraiLoggerPlatformBase
 import net.mamoe.mirai.utils.SimpleLogger
 
 internal class MiraiConsoleLogger(
-    private val controller: LoggerController,
+    controller: LoggerController,
     val logger: MiraiLogger
 ) : MiraiLoggerPlatformBase() {
     override val identity: String? get() = logger.identity
     override val isEnabled: Boolean get() = logger.isEnabled
 
+    private val logState = controller.getLoggerControlState(identity)
+
     override val isInfoEnabled: Boolean
-        get() = controller.shouldLog(identity, SimpleLogger.LogPriority.INFO)
+        get() = logState.shouldLog(SimpleLogger.LogPriority.INFO)
     override val isWarningEnabled: Boolean
-        get() = controller.shouldLog(identity, SimpleLogger.LogPriority.WARNING)
+        get() = logState.shouldLog(SimpleLogger.LogPriority.WARNING)
     override val isDebugEnabled: Boolean
-        get() = controller.shouldLog(identity, SimpleLogger.LogPriority.DEBUG)
+        get() = logState.shouldLog(SimpleLogger.LogPriority.DEBUG)
     override val isErrorEnabled: Boolean
-        get() = controller.shouldLog(identity, SimpleLogger.LogPriority.ERROR)
+        get() = logState.shouldLog(SimpleLogger.LogPriority.ERROR)
     override val isVerboseEnabled: Boolean
-        get() = controller.shouldLog(identity, SimpleLogger.LogPriority.VERBOSE)
+        get() = logState.shouldLog(SimpleLogger.LogPriority.VERBOSE)
 
     override fun info0(message: String?, e: Throwable?) {
-        if (controller.shouldLog(identity, SimpleLogger.LogPriority.INFO))
+        if (logState.shouldLog(SimpleLogger.LogPriority.INFO))
             logger.info(message, e)
     }
 
     override fun warning0(message: String?, e: Throwable?) {
-        if (controller.shouldLog(identity, SimpleLogger.LogPriority.WARNING))
+        if (logState.shouldLog(SimpleLogger.LogPriority.WARNING))
             logger.warning(message, e)
     }
 
     override fun debug0(message: String?, e: Throwable?) {
-        if (controller.shouldLog(identity, SimpleLogger.LogPriority.DEBUG))
+        if (logState.shouldLog(SimpleLogger.LogPriority.DEBUG))
             logger.debug(message, e)
     }
 
     override fun error0(message: String?, e: Throwable?) {
-        if (controller.shouldLog(identity, SimpleLogger.LogPriority.ERROR))
+        if (logState.shouldLog(SimpleLogger.LogPriority.ERROR))
             logger.error(message, e)
     }
 
     override fun verbose0(message: String?, e: Throwable?) {
-        if (controller.shouldLog(identity, SimpleLogger.LogPriority.VERBOSE))
+        if (logState.shouldLog(SimpleLogger.LogPriority.VERBOSE))
             logger.verbose(message, e)
     }
 }

--- a/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/MiraiConsoleSLF4JService.kt
+++ b/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/MiraiConsoleSLF4JService.kt
@@ -70,7 +70,7 @@ internal object MiraiConsoleSLF4JAdapter {
             }
             initialized = true
 
-            // region relay events
+            // region replay events
 
             substituteServiceFactory.postInitialization()
             substituteServiceFactory.loggers.forEach { slog ->

--- a/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/MiraiConsoleSLF4JService.kt
+++ b/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/MiraiConsoleSLF4JService.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019-2022 Mamoe Technologies and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/mamoe/mirai/blob/dev/LICENSE
+ */
+
+package net.mamoe.mirai.console.internal.logging.externalbind.slf4j
+
+import net.mamoe.mirai.console.MiraiConsoleImplementation.ConsoleDataScope.Companion.get
+import net.mamoe.mirai.console.internal.data.builtins.DataScope
+import net.mamoe.mirai.console.internal.data.builtins.LoggerConfig
+import net.mamoe.mirai.utils.MiraiLogger
+import net.mamoe.mirai.utils.safeCast
+import org.slf4j.ILoggerFactory
+import org.slf4j.IMarkerFactory
+import org.slf4j.event.SubstituteLoggingEvent
+import org.slf4j.helpers.BasicMarkerFactory
+import org.slf4j.helpers.NOPLoggerFactory
+import org.slf4j.helpers.NOPMDCAdapter
+import org.slf4j.helpers.SubstituteLoggerFactory
+import org.slf4j.spi.MDCAdapter
+import org.slf4j.spi.SLF4JServiceProvider
+
+@PublishedApi
+internal class MiraiConsoleSLF4JService : SLF4JServiceProvider {
+    private val basicMarkerFactory = BasicMarkerFactory()
+    private val nopMDCAdapter = NOPMDCAdapter()
+    private val dfactory = ILoggerFactory { MiraiConsoleSLF4JAdapter.getCurrentLogFactory().getLogger(it) }
+
+    override fun getMarkerFactory(): IMarkerFactory = basicMarkerFactory
+    override fun getMDCAdapter(): MDCAdapter = nopMDCAdapter
+    override fun getRequestedApiVersion(): String = "2.0"
+    override fun getLoggerFactory(): ILoggerFactory = dfactory
+    override fun initialize() {}
+}
+
+internal object MiraiConsoleSLF4JAdapter {
+    /**
+     * Used before mirai-console start
+     */
+    private val substituteServiceFactory = SubstituteLoggerFactory()
+
+    @Volatile
+    private var initialized: Boolean = false
+
+    @Volatile
+    private var currentLoggerFactory: ILoggerFactory = substituteServiceFactory
+
+    internal fun getCurrentLogFactory(): ILoggerFactory {
+        if (initialized) return currentLoggerFactory
+
+        synchronized(MiraiConsoleSLF4JAdapter::class.java) {
+            return currentLoggerFactory
+        }
+    }
+
+    internal fun doSlf4JInit() {
+        synchronized(MiraiConsoleSLF4JAdapter::class.java) {
+            val logConfig = DataScope.get<LoggerConfig>()
+
+            currentLoggerFactory = if (logConfig.binding.slf4j) {
+                ILoggerFactory { ident ->
+                    SLF4JAdapterLogger(MiraiLogger.Factory.create(MiraiConsoleSLF4JAdapter::class.java, ident))
+                }
+            } else {
+                NOPLoggerFactory()
+            }
+            initialized = true
+
+            // region relay events
+
+            substituteServiceFactory.postInitialization()
+            substituteServiceFactory.loggers.forEach { slog ->
+                slog.setDelegate(currentLoggerFactory.getLogger(slog.name))
+            }
+
+            substituteServiceFactory.eventQueue.let { queue ->
+                for (event in queue) {
+                    replaySingleEvent(event)
+                }
+            }
+            substituteServiceFactory.clear()
+            // endregion
+        }
+    }
+
+
+    private fun replaySingleEvent(event: SubstituteLoggingEvent?) {
+        if (event == null) return
+        val substLogger = event.logger
+
+        substLogger.delegate().safeCast<SLF4JAdapterLogger>()?.process(event)
+    }
+
+}

--- a/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/SLF4JAdapterLogger.kt
+++ b/mirai-console/backend/mirai-console/src/internal/logging/externalbind/slf4j/SLF4JAdapterLogger.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2019-2022 Mamoe Technologies and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/mamoe/mirai/blob/dev/LICENSE
+ */
+
+package net.mamoe.mirai.console.internal.logging.externalbind.slf4j
+
+import net.mamoe.mirai.utils.MiraiLogger
+import org.slf4j.Logger
+import org.slf4j.Marker
+import org.slf4j.event.SubstituteLoggingEvent
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.nio.CharBuffer
+import java.text.MessageFormat
+import java.util.regex.Pattern
+import org.slf4j.event.Level as SLF4JEventLevel
+
+@Suppress("RegExpRedundantEscape")
+internal class SLF4JAdapterLogger(
+    private val logger: MiraiLogger
+) : Logger {
+    // Copied from Log4J
+    internal companion object {
+        private const val FORMAT_SPECIFIER = "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])"
+
+        private val MSG_PATTERN = Pattern.compile(FORMAT_SPECIFIER)
+        private const val DELIM_START = '{'
+        private const val DELIM_STOP = '}'
+        private const val ESCAPE_CHAR = '\\'
+
+        @JvmStatic
+        internal fun String.simpleFormat(args: Array<out Any?>): String {
+            val buffer = StringBuilder()
+            val reader = CharBuffer.wrap(this)
+            var isEscape = false
+            var index = 0
+            while (reader.hasRemaining()) {
+                when (val next = reader.get()) {
+                    ESCAPE_CHAR -> {
+                        if (isEscape) {
+                            buffer.append(ESCAPE_CHAR)
+                        }
+                        isEscape = !isEscape
+                    }
+                    DELIM_START -> {
+                        if (isEscape) {
+                            buffer.append(next)
+                        } else {
+                            if (reader.hasRemaining()) {
+                                if (reader.get(reader.position()) == DELIM_STOP) {
+                                    reader.get()
+                                    buffer.append(args.getOrNull(index))
+                                    index++
+                                } else {
+                                    buffer.append(DELIM_START)
+                                }
+                            } else {
+                                buffer.append(DELIM_START)
+                            }
+                        }
+                        isEscape = false
+                    }
+                    else -> buffer.append(next).also { isEscape = false }
+                }
+            }
+            return buffer.toString()
+        }
+
+        internal fun String.format1(vararg arguments: Any?): String = format2(arguments)
+
+        // (java.lang.String, java.lang.Object[]): java.lang.String
+        @Suppress("LocalVariableName")
+        private val formatWithLog4JMH: MethodHandle? = kotlin.runCatching {
+            val c_ParameterizedMessage = Class.forName("org.apache.logging.log4j.message.ParameterizedMessage")
+
+            val mhLookup = MethodHandles.lookup()
+            val mh_newParameterizedMessage = mhLookup.findConstructor(
+                c_ParameterizedMessage, MethodType.methodType(Void.TYPE, String::class.java, Array<Any>::class.java)
+            ).asFixedArity()
+
+            val mh_getFormattedMessage = mhLookup.findVirtual(
+                c_ParameterizedMessage, "getFormattedMessage", MethodType.methodType(String::class.java)
+            )
+
+            MethodHandles.filterReturnValue(mh_newParameterizedMessage, mh_getFormattedMessage)
+
+        }.getOrNull()
+
+        @JvmStatic
+        internal fun String.format2(args: Array<out Any?>): String {
+            kotlin.runCatching {
+                val formatter = MessageFormat(this)
+                val formats = formatter.formats
+                if (formats.isNotEmpty()) {
+                    return formatter.format(args)
+                }
+            }
+            kotlin.runCatching {
+                if (MSG_PATTERN.matcher(this).find()) {
+                    return String.format(this, *args)
+                }
+            }
+            kotlin.runCatching {
+                // Try format with Log4J
+                formatWithLog4JMH?.let { formatWithLog4JMH ->
+                    return formatWithLog4JMH.invoke(this@format2, args) as String
+                }
+            }
+            return simpleFormat(args)
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////
+    override fun isTraceEnabled(): Boolean = logger.isVerboseEnabled
+    override fun isTraceEnabled(marker: Marker?): Boolean = logger.isVerboseEnabled
+    override fun isDebugEnabled(): Boolean = logger.isDebugEnabled
+    override fun isDebugEnabled(marker: Marker?): Boolean = logger.isDebugEnabled
+    override fun isInfoEnabled(): Boolean = logger.isInfoEnabled
+    override fun isInfoEnabled(marker: Marker?): Boolean = logger.isInfoEnabled
+    override fun isWarnEnabled(): Boolean = logger.isWarningEnabled
+    override fun isWarnEnabled(marker: Marker?): Boolean = logger.isWarningEnabled
+    override fun isErrorEnabled(): Boolean = logger.isErrorEnabled
+    override fun isErrorEnabled(marker: Marker?): Boolean = logger.isErrorEnabled
+    //////////////////////////////////////////////////////////////////
+
+    override fun getName(): String = logger.identity ?: "<unknown>"
+
+    @Suppress("DuplicatedCode")
+    internal fun process(event: SubstituteLoggingEvent) {
+        val msg = event.message
+        val argx = event.argumentArray
+        val throwx = event.throwable
+
+        val evtlv = event.level ?: return
+
+        val isEnabled = when (evtlv) {
+            SLF4JEventLevel.ERROR -> isErrorEnabled
+            SLF4JEventLevel.WARN -> isWarnEnabled
+            SLF4JEventLevel.INFO -> isInfoEnabled
+            SLF4JEventLevel.DEBUG -> isDebugEnabled
+            SLF4JEventLevel.TRACE -> isTraceEnabled
+        }
+        if (!isEnabled) return
+
+        if (argx == null) {
+            when (evtlv) {
+                SLF4JEventLevel.ERROR -> error(msg, t = throwx)
+                SLF4JEventLevel.WARN -> warn(msg, t = throwx)
+                SLF4JEventLevel.INFO -> info(msg, t = throwx)
+                SLF4JEventLevel.DEBUG -> debug(msg, t = throwx)
+                SLF4JEventLevel.TRACE -> trace(msg, t = throwx)
+            }
+            return
+        }
+
+        if (throwx == null) {
+            when (evtlv) {
+                SLF4JEventLevel.ERROR -> error(msg, arguments = argx)
+                SLF4JEventLevel.WARN -> warn(msg, arguments = argx)
+                SLF4JEventLevel.INFO -> info(msg, arguments = argx)
+                SLF4JEventLevel.DEBUG -> debug(msg, arguments = argx)
+                SLF4JEventLevel.TRACE -> trace(msg, arguments = argx)
+            }
+            return
+        }
+
+        val msg2 = msg.format2(argx)
+        when (evtlv) {
+            SLF4JEventLevel.ERROR -> error(msg2, t = throwx)
+            SLF4JEventLevel.WARN -> warn(msg2, t = throwx)
+            SLF4JEventLevel.INFO -> info(msg2, t = throwx)
+            SLF4JEventLevel.DEBUG -> debug(msg2, t = throwx)
+            SLF4JEventLevel.TRACE -> trace(msg2, t = throwx)
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    private inline fun iT(a: () -> Unit) {
+        if (isTraceEnabled) a()
+    }
+
+    private inline fun iD(a: () -> Unit) {
+        if (isDebugEnabled) a()
+    }
+
+    private inline fun iI(a: () -> Unit) {
+        if (isInfoEnabled) a()
+    }
+
+    private inline fun iW(a: () -> Unit) {
+        if (isWarnEnabled) a()
+    }
+
+    private inline fun iE(a: () -> Unit) {
+        if (isErrorEnabled) a()
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    override fun trace(msg: String?) {
+        logger.verbose(msg)
+    }
+
+    override fun trace(msg: String?, t: Throwable?) {
+        logger.verbose(msg, t)
+    }
+
+    override fun trace(format: String, arg: Any?) = iT { trace(format.format1(arg)) }
+    override fun trace(format: String, arg1: Any?, arg2: Any?) = iT { trace(format.format1(arg1, arg2)) }
+    override fun trace(format: String, arguments: Array<out Any?>) = iT { trace(format.format2(arguments)) }
+
+    override fun trace(marker: Marker?, msg: String?) = trace(msg)
+    override fun trace(marker: Marker?, format: String, arg: Any?) = trace(format, arg)
+    override fun trace(marker: Marker?, format: String, arg1: Any?, arg2: Any?) = trace(format, arg1, arg2)
+    override fun trace(marker: Marker?, format: String, argArray: Array<out Any?>) = trace(format, argArray)
+    override fun trace(marker: Marker?, msg: String?, t: Throwable?) = trace(msg, t)
+
+    //////////////////////////////////////////////////////////////////
+
+    override fun debug(msg: String?) {
+        logger.debug(msg)
+    }
+
+    override fun debug(msg: String?, t: Throwable?) {
+        logger.debug(msg, t)
+    }
+
+    override fun debug(format: String, arg: Any?) = iD { debug(format.format1(arg)) }
+    override fun debug(format: String, arg1: Any?, arg2: Any?) = iD { debug(format.format1(arg1, arg2)) }
+    override fun debug(format: String, arguments: Array<out Any?>) = iD { debug(format.format2(arguments)) }
+
+    override fun debug(marker: Marker?, msg: String?) = debug(msg)
+    override fun debug(marker: Marker?, format: String, arg: Any?) = debug(format, arg)
+    override fun debug(marker: Marker?, format: String, arg1: Any?, arg2: Any?) = debug(format, arg1, arg2)
+    override fun debug(marker: Marker?, format: String, arguments: Array<out Any?>) = debug(format, arguments)
+    override fun debug(marker: Marker?, msg: String?, t: Throwable?) = debug(msg, t)
+
+    //////////////////////////////////////////////////////////////////
+
+    override fun info(msg: String?) {
+        logger.info(msg)
+    }
+
+    override fun info(msg: String?, t: Throwable?) {
+        logger.info(msg, t)
+    }
+
+    override fun info(format: String, arg: Any?) = iI { info(format.format1(arg)) }
+    override fun info(format: String, arg1: Any?, arg2: Any?) = iI { info(format.format1(arg1, arg2)) }
+    override fun info(format: String, arguments: Array<out Any?>) = iI { info(format.format2(arguments)) }
+
+    override fun info(marker: Marker?, msg: String?) = info(msg)
+    override fun info(marker: Marker?, format: String, arg: Any?) = info(format, arg)
+    override fun info(marker: Marker?, format: String, arg1: Any?, arg2: Any?) = info(format, arg1, arg2)
+    override fun info(marker: Marker?, format: String, arguments: Array<out Any?>) = info(format, arguments)
+    override fun info(marker: Marker?, msg: String?, t: Throwable?) = info(msg, t)
+
+    //////////////////////////////////////////////////////////////////
+
+    override fun warn(msg: String?) {
+        logger.warning(msg)
+    }
+
+    override fun warn(msg: String?, t: Throwable?) {
+        logger.warning(msg, t)
+    }
+
+    override fun warn(format: String, arg: Any?) = iW { warn(format.format1(arg)) }
+    override fun warn(format: String, arguments: Array<out Any?>) = iW { warn(format.format2(arguments)) }
+    override fun warn(format: String, arg1: Any?, arg2: Any?) = iW { warn(format.format1(arg1, arg2)) }
+
+    override fun warn(marker: Marker?, msg: String?) = warn(msg)
+    override fun warn(marker: Marker?, format: String, arg: Any?) = warn(format, arg)
+    override fun warn(marker: Marker?, format: String, arg1: Any?, arg2: Any?) = warn(format, arg1, arg2)
+    override fun warn(marker: Marker?, format: String, arguments: Array<out Any?>) = warn(format, arguments)
+    override fun warn(marker: Marker?, msg: String?, t: Throwable?) = warn(msg, t)
+
+    //////////////////////////////////////////////////////////////////
+
+    override fun error(msg: String?) {
+        logger.error(msg)
+    }
+
+    override fun error(msg: String?, t: Throwable?) {
+        logger.error(msg, t)
+    }
+
+    override fun error(format: String, arg: Any?) = iE { error(format.format1(arg)) }
+    override fun error(format: String, arg1: Any?, arg2: Any?) = iE { error(format.format1(arg1, arg2)) }
+    override fun error(format: String, arguments: Array<out Any?>) = iE { error(format.format2(arguments)) }
+
+    override fun error(marker: Marker?, msg: String?) = error(msg)
+    override fun error(marker: Marker?, format: String, arg: Any?) = error(format, arg)
+    override fun error(marker: Marker?, format: String, arg1: Any?, arg2: Any?) = error(format, arg1, arg2)
+    override fun error(marker: Marker?, format: String, arguments: Array<out Any?>) = error(format, arguments)
+    override fun error(marker: Marker?, msg: String?, t: Throwable?) = error(msg, t)
+}

--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
@@ -129,7 +129,12 @@ internal class DynLibClassLoader : DynamicClasspathClassLoader {
             if (name in AllDependenciesClassesHolder.allclasses) {
                 return AllDependenciesClassesHolder.appClassLoader.loadClass(name)
             }
-            if (name.startsWith("net.mamoe.mirai.") || name.startsWith("kotlin.") || name.startsWith("kotlinx.")) { // Avoid plugin classing cheating
+            if (
+                name.startsWith("net.mamoe.mirai.")
+                || name.startsWith("kotlin.")
+                || name.startsWith("kotlinx.")
+                || name.startsWith("org.slf4j.")
+            ) { // Avoid plugin classing cheating
                 try {
                     return AllDependenciesClassesHolder.appClassLoader.loadClass(name)
                 } catch (ignored: ClassNotFoundException) {

--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginDependencyDownload.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginDependencyDownload.kt
@@ -80,6 +80,11 @@ internal class JvmPluginDependencyDownloader(
             ) return@DependencyFilter false
         }
 
+        // Re-download slf4j-api is unnecessary since slf4j-api was bound by console
+        if (artGroup == "org.slf4j" && artId == "slf4j-api") {
+            return@DependencyFilter false
+        }
+
         // Loaded by console system
         if ("$artGroup:$artId" in MiraiConsoleBuildDependencies.dependencies)
             return@DependencyFilter false

--- a/mirai-console/backend/mirai-console/src/logging/LoggerController.kt
+++ b/mirai-console/backend/mirai-console/src/logging/LoggerController.kt
@@ -12,6 +12,7 @@ package net.mamoe.mirai.console.logging
 import net.mamoe.mirai.console.MiraiConsoleImplementation
 import net.mamoe.mirai.console.internal.logging.MiraiConsoleLogger
 import net.mamoe.mirai.console.util.ConsoleExperimentalApi
+import net.mamoe.mirai.utils.MiraiLogger
 import net.mamoe.mirai.utils.SimpleLogger
 
 /**
@@ -26,4 +27,23 @@ public interface LoggerController {
     /** 是否应该记录该等级的日志 */
     public fun shouldLog(identity: String?, priority: SimpleLogger.LogPriority): Boolean
 
+    public fun getLoggerControlState(identity: String?): LoggerControlState {
+        return object : LoggerControlState {
+            override fun shouldLog(priority: SimpleLogger.LogPriority): Boolean {
+                return shouldLog(identity, priority)
+            }
+        }
+    }
+
+    /**
+     * 一个 [MiraiLogger] 的日志开关状态
+     *
+     * 这个类可以缓存 [LoggerController.shouldLog] 的结果, 避免多次查询
+     *
+     * 在需要的时候会自动更新, 所以不需要手动更换 [LoggerControlState]
+     */
+    @ConsoleExperimentalApi
+    public interface LoggerControlState {
+        public fun shouldLog(priority: SimpleLogger.LogPriority): Boolean
+    }
 }

--- a/mirai-console/backend/mirai-console/test/logging/TestALC.kt
+++ b/mirai-console/backend/mirai-console/test/logging/TestALC.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019-2022 Mamoe Technologies and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+ *
+ * https://github.com/mamoe/mirai/blob/dev/LICENSE
+ */
+
+package net.mamoe.mirai.console.logging
+
+import net.mamoe.mirai.utils.SimpleLogger
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class TestALC {
+    private class TestController(
+        override val isLoggerControlStateSupported: Boolean,
+    ) : AbstractLoggerController() {
+        var callcount = 0
+
+
+        override fun getPriority(identity: String?): LogPriority {
+            return LogPriority.ALL
+        }
+
+        override fun shouldLog(identity: String?, priority: SimpleLogger.LogPriority): Boolean {
+            if (priority == SimpleLogger.LogPriority.INFO) {
+                callcount++
+            }
+            return super.shouldLog(identity, priority)
+        }
+    }
+
+    @Test
+    fun `test logger control state caching`() {
+        val controller = TestController(true)
+        assertEquals(0, controller.callcount)
+        val state = controller.getLoggerControlState("Test")
+        assertEquals(0, controller.callcount) // lazy load
+
+        state.shouldLog(SimpleLogger.LogPriority.DEBUG)
+        assertEquals(1, controller.callcount)
+
+        state.shouldLog(SimpleLogger.LogPriority.INFO)
+        assertEquals(1, controller.callcount)
+
+        state.shouldLog(SimpleLogger.LogPriority.DEBUG)
+        state.shouldLog(SimpleLogger.LogPriority.INFO)
+        state.shouldLog(SimpleLogger.LogPriority.INFO)
+        assertEquals(1, controller.callcount)
+    }
+
+    @Test
+    fun `test keep binary compatibility`() {
+        val controller = TestController(false)
+        assertEquals(0, controller.callcount)
+        val state = controller.getLoggerControlState("Test")
+        assertEquals(0, controller.callcount)
+
+        repeat(50) { count ->
+            state.shouldLog(SimpleLogger.LogPriority.INFO)
+            assertEquals(count + 1, controller.callcount)
+        }
+    }
+}

--- a/mirai-console/backend/mirai-console/test/logging/TestAbstractLoggerController.kt
+++ b/mirai-console/backend/mirai-console/test/logging/TestAbstractLoggerController.kt
@@ -13,7 +13,7 @@ import net.mamoe.mirai.utils.SimpleLogger
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-internal class TestALC {
+internal class TestAbstractLoggerController {
     private class TestController(
         override val isLoggerControlStateSupported: Boolean,
     ) : AbstractLoggerController() {

--- a/mirai-console/backend/mirai-console/test/logging/TestAbstractLoggerController_PathBased.kt
+++ b/mirai-console/backend/mirai-console/test/logging/TestAbstractLoggerController_PathBased.kt
@@ -12,7 +12,7 @@ package net.mamoe.mirai.console.logging
 import kotlin.test.Test
 
 @Suppress("ClassName")
-internal class TestALC_PathBased {
+internal class TestAbstractLoggerController_PathBased {
     @Test
     fun `test AbstractLoggerController$PathBased`() {
         val config = mapOf(

--- a/mirai-core-all/build.gradle.kts
+++ b/mirai-core-all/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":mirai-core"))
     api(project(":mirai-core-api"))
     api(project(":mirai-core-utils"))
+    implementation(`slf4j-api`) // Required by mirai-console
 
     relocateImplementation(project, `ktor-client-core_relocated`)
     relocateImplementation(project, `ktor-client-okhttp_relocated`)


### PR DESCRIPTION
# 主修改

- [X] 优化 MiraiLogger (in console) 性能
- [X] SLF4J 支持

# 配置文件修改

> 修改均为默认配置, 先前已经生成的配置不会进行修改

### `Logger.yml`

```diff
 # 默认日志输出等级
 # 可选值: ALL, VERBOSE, DEBUG, INFO, WARNING, ERROR, NONE
 defaultPriority: INFO
 # 特定日志记录器输出等级
 loggers: 
   example.logger: NONE
   console.debug: NONE
   Bot: ALL
+  org.eclipse.aether.internal: INFO
+  org.apache.http.wire: INFO

+# 是否启动外部日志框架桥接
+binding: 
+  slf4j: true
```

# ABI Changes

> 注: 实际上 console 并没有直接的 abi changes

依赖更新: `org.slf4j:slf4j-api:1.7.32` -> `2.0.3`

此依赖的更新只会影响 `slf4j-api` 的对接, 并不会影响 `slf4j-api` 的单纯使用

> 即不会对插件有任何影响, 只会对部分对 console 进行高度自定义的会有少许影响

