### PR TITLE
修复 java.lang.NoSuchMethodError

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginInternal.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginInternal.kt
@@ -126,7 +126,12 @@ internal abstract class JvmPluginInternal(
         parentPermission
         if (!firstRun) refreshCoroutineContext()
 
-        val except = javaClass.getDeclaredAnnotation(ConsoleJvmPluginFuncCallbackStatusExcept.OnEnable::class.java)
+        val except = try {
+            javaClass.getDeclaredAnnotation(ConsoleJvmPluginFuncCallbackStatusExcept.OnEnable::class.java)
+        }catch(e: Throwable){
+            null
+        }
+        
         kotlin.runCatching {
             onEnable()
         }.fold(

--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginInternal.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginInternal.kt
@@ -128,10 +128,10 @@ internal abstract class JvmPluginInternal(
 
         val except = try {
             javaClass.getDeclaredAnnotation(ConsoleJvmPluginFuncCallbackStatusExcept.OnEnable::class.java)
-        }catch(e: Throwable){
+        } catch (e: Throwable) {
             null
         }
-        
+
         kotlin.runCatching {
             onEnable()
         }.fold(


### PR DESCRIPTION
修复在较低版本的安桌系统的报错 java.lang.NoSuchMethodError: No virtual method getDeclaredAnnotation(Ljava/lang/Class;)L

当函数不存在作null处理