### PR TITLE
[console/plugin] Fix multi-dependency-repositories not working

### DIFF
--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginDependencyDownload.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginDependencyDownload.kt
@@ -252,7 +252,7 @@ internal class JvmPluginDependencyDownloader(
         repositories = repository.newResolutionRepositories(
             session,
             config.repoLoc.map { url ->
-                RemoteRepository.Builder(null, "default", url).build()
+                RemoteRepository.Builder(url, "default", url).build()
             }
         )
         logger.debug { "Remote server: " + config.repoLoc }


### PR DESCRIPTION
RemoteRepository 没有提供 id (相当于所有id都为空), 导致 repoLoc 列表只有第一个生效 (剩下的url因为id相同被过滤)