### PR TITLE
fix: friendGroupId default value

### DIFF
--- a/mirai-core/src/commonMain/kotlin/contact/info/FriendInfoImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/contact/info/FriendInfoImpl.kt
@@ -18,7 +18,7 @@ internal data class FriendInfoImpl(
     override val uin: Long,
     override var nick: String,
     override var remark: String,
-    override var friendGroupId: Int
+    override var friendGroupId: Int = 0
 ) : FriendInfo {
     companion object {
         fun FriendInfo.impl() = if (this is FriendInfoImpl) this else FriendInfoImpl(uin, nick, remark, friendGroupId)


### PR DESCRIPTION
for https://mirai.mamoe.net/topic/1895

```
kotlinx.serialization.MissingFieldException: Field 'friendGroupId' is required for type with serial name 'net.mamoe.mirai.internal.contact.info.FriendInfoImpl', but it was missing at path: $.list[0] at path: $.list[0] at path: $.list[0]
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:40)
	at kotlinx.serialization.json.Json.decodeFromString(Json.kt:100)
	at net.mamoe.mirai.utils.SerializationKt_common.loadNotBlankAs(Serialization.kt:76)
	at net.mamoe.mirai.internal.network.components.ContactCacheServiceImpl$friendListCache$2.invoke(ContactCacheService.kt:63)
	at net.mamoe.mirai.internal.network.components.ContactCacheServiceImpl$friendListCache$2.invoke(ContactCacheService.kt:60)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at net.mamoe.mirai.internal.network.components.ContactCacheServiceImpl.getFriendListCache(ContactCacheService.kt:60)
	at net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc$Register$online$1.invoke(StatSvc.kt:186)
	at net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc$Register$online$1.invoke(StatSvc.kt:168)
	at net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc$Register.impl(StatSvc.kt:273)
	at net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc$Register.online(StatSvc.kt:168)
	at net.mamoe.mirai.internal.network.protocol.packet.login.StatSvc$Register.online$default(StatSvc.kt:165)
	at net.mamoe.mirai.internal.network.components.SsoProcessorImpl.registerClientOnline(SsoProcessor.kt:165)
	at net.mamoe.mirai.internal.network.components.SsoProcessorImpl.login(SsoProcessor.kt:156)
	at net.mamoe.mirai.internal.network.components.SsoProcessorImpl$login$1.invokeSuspend(SsoProcessor.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:33)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
Caused by: kotlinx.serialization.MissingFieldException: Field 'friendGroupId' is required for type with serial name 'net.mamoe.mirai.internal.contact.info.FriendInfoImpl', but it was missing at path: $.list[0] at path: $.list[0]
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:40)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:111)
	at net.mamoe.mirai.internal.network.FriendListCache$$serializer.deserialize(ContactListCache.kt:34)
	at net.mamoe.mirai.internal.network.FriendListCache$$serializer.deserialize(ContactListCache.kt:34)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:59)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:38)
	... 23 more
Caused by: kotlinx.serialization.MissingFieldException: Field 'friendGroupId' is required for type with serial name 'net.mamoe.mirai.internal.contact.info.FriendInfoImpl', but it was missing at path: $.list[0]
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:40)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:43)
	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableElement(AbstractDecoder.kt:70)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableElement(StreamingJsonDecoder.kt:111)
	at kotlinx.serialization.encoding.CompositeDecoder$DefaultImpls.decodeSerializableElement$default(Decoding.kt:537)
	at kotlinx.serialization.internal.CollectionLikeSerializer.readElement(CollectionSerializers.kt:80)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.readElement$default(CollectionSerializers.kt:51)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.merge(CollectionSerializers.kt:36)
	at kotlinx.serialization.internal.AbstractCollectionSerializer.deserialize(CollectionSerializers.kt:43)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:59)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:38)
	... 30 more
Caused by: kotlinx.serialization.MissingFieldException: Field 'friendGroupId' is required for type with serial name 'net.mamoe.mirai.internal.contact.info.FriendInfoImpl', but it was missing
	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
	at net.mamoe.mirai.internal.contact.info.FriendInfoImpl.<init>(FriendInfoImpl.kt:16)
	at net.mamoe.mirai.internal.contact.info.FriendInfoImpl$$serializer.deserialize(FriendInfoImpl.kt:16)
	at net.mamoe.mirai.internal.contact.info.FriendInfoImpl$$serializer.deserialize(FriendInfoImpl.kt:16)
	at kotlinx.serialization.json.internal.PolymorphicKt.decodeSerializableValuePolymorphic(Polymorphic.kt:59)
	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:38)
	... 40 more
```