### PR TITLE
[core] Fix polymorphic serialization

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/contact/announcement/OfflineAnnouncement.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/announcement/OfflineAnnouncement.kt
@@ -84,7 +84,7 @@ public sealed interface OfflineAnnouncement : Announcement {
         }
 
         internal object Serializer : KSerializer<OfflineAnnouncement> by OfflineAnnouncementImpl.serializer().map(
-            resultantDescriptor = OfflineAnnouncementImpl.serializer().descriptor.copy(SERIAL_NAME),
+            resultantDescriptor = OfflineAnnouncementImpl.serializer().descriptor,
             deserialize = { it },
             serialize = { it.safeCast<OfflineAnnouncementImpl>() ?: create(content, parameters).cast() }
         )

--- a/mirai-core-api/src/commonMain/kotlin/internal/message/MessageSerializersImpl.kt
+++ b/mirai-core-api/src/commonMain/kotlin/internal/message/MessageSerializersImpl.kt
@@ -38,6 +38,12 @@ public open class MessageSourceSerializerImpl(serialName: String) :
             Mirai.constructMessageSource(botId, kind, fromId, targetId, ids, time, internalIds, originalMessage)
         }
     ) {
+
+    @MiraiInternalApi
+    public companion object {
+        public fun serialDataSerializer(): KSerializer<*> = SerialData.serializer()
+    }
+
     @SerialName(MessageSource.SERIAL_NAME)
     @Serializable
     internal class SerialData(

--- a/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/FileMessage.kt
@@ -25,7 +25,6 @@ import net.mamoe.mirai.message.code.CodableMessage
 import net.mamoe.mirai.message.data.visitor.MessageVisitor
 import net.mamoe.mirai.utils.MiraiInternalApi
 import net.mamoe.mirai.utils.NotStableForInheritance
-import net.mamoe.mirai.utils.copy
 import net.mamoe.mirai.utils.map
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
@@ -111,9 +110,9 @@ public expect interface FileMessage : MessageContent, ConstrainSingle, CodableMe
 }
 
 @MiraiInternalApi
-internal open class FallbackFileMessageSerializer constructor(serialName: String) :
+internal open class FallbackFileMessageSerializer :
     KSerializer<FileMessage> by Delegate.serializer().map(
-        Delegate.serializer().descriptor.copy(serialName),
+        Delegate.serializer().descriptor,
         serialize = { Delegate(id, internalId, name, size) },
         deserialize = { Mirai.createFileMessage(id, internalId, name, size) },
     ) {

--- a/mirai-core-api/src/commonMain/kotlin/message/data/RockPaperScissors.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/RockPaperScissors.kt
@@ -102,7 +102,7 @@ public enum class RockPaperScissors(
     }
 
     internal object Serializer : KSerializer<RockPaperScissors> by Surrogate.serializer().map(
-        resultantDescriptor = Surrogate.serializer().descriptor.copy(SERIAL_NAME),
+        resultantDescriptor = Surrogate.serializer().descriptor,
         deserialize = { valueOf(it.name) },
         serialize = { Surrogate(name) },
     ) {

--- a/mirai-core-api/src/commonMain/kotlin/message/data/UnsupportedMessage.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/UnsupportedMessage.kt
@@ -62,7 +62,7 @@ public interface UnsupportedMessage : MessageContent {
     }
 
     public object Serializer : KSerializer<UnsupportedMessage> by Surrogate.serializer().map(
-        resultantDescriptor = Surrogate.serializer().descriptor.copy(SERIAL_NAME),
+        resultantDescriptor = Surrogate.serializer().descriptor,
         deserialize = { Mirai.createUnsupportedMessage(struct.hexToBytes()) },
         serialize = { Surrogate(struct.toUHexString("")) }
     ) {

--- a/mirai-core-api/src/commonMain/kotlin/utils/DeviceInfo.kt
+++ b/mirai-core-api/src/commonMain/kotlin/utils/DeviceInfo.kt
@@ -11,6 +11,7 @@ package net.mamoe.mirai.utils
 
 import io.ktor.utils.io.core.*
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.builtins.serializer
@@ -292,7 +293,7 @@ internal object DeviceInfoManager {
     )
 
     private object DeviceInfoVersionSerializer : KSerializer<DeviceInfo.Version> by SerialData.serializer().map(
-        resultantDescriptor = SerialData.serializer().descriptor.copy("Version"),
+        resultantDescriptor = SerialData.serializer().descriptor,
         deserialize = {
             DeviceInfo.Version(incremental, release, codename, sdk)
         },
@@ -300,6 +301,7 @@ internal object DeviceInfoManager {
             SerialData(incremental, release, codename, sdk)
         }
     ) {
+        @SerialName("Version")
         @Serializable
         private class SerialData(
             val incremental: ByteArray = "5891938".toByteArray(),

--- a/mirai-core-api/src/jvmBaseMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/jvmBaseMain/kotlin/message/data/FileMessage.kt
@@ -120,5 +120,5 @@ public actual interface FileMessage : MessageContent, ConstrainSingle, CodableMe
     }
 
     public actual object Serializer :
-        KSerializer<FileMessage> by FallbackFileMessageSerializer(SERIAL_NAME) // not polymorphic
+        KSerializer<FileMessage> by FallbackFileMessageSerializer()
 }

--- a/mirai-core-api/src/nativeMain/kotlin/message/data/FileMessage.kt
+++ b/mirai-core-api/src/nativeMain/kotlin/message/data/FileMessage.kt
@@ -104,5 +104,5 @@ public actual interface FileMessage : MessageContent, ConstrainSingle, CodableMe
     }
 
     public actual object Serializer :
-        KSerializer<FileMessage> by FallbackFileMessageSerializer(SERIAL_NAME) // not polymorphic
+        KSerializer<FileMessage> by FallbackFileMessageSerializer()
 }

--- a/mirai-core/src/commonMain/kotlin/message/data/audio.kt
+++ b/mirai-core/src/commonMain/kotlin/message/data/audio.kt
@@ -163,7 +163,7 @@ internal class OnlineAudioImpl(
     }
 
     object Serializer : KSerializer<OnlineAudioImpl> by Surrogate.serializer().map(
-        resultantDescriptor = Surrogate.serializer().descriptor.copy(OnlineAudio.SERIAL_NAME),
+        resultantDescriptor = Surrogate.serializer().descriptor,
         deserialize = {
             OnlineAudioImpl(
                 filename = filename,
@@ -251,7 +251,7 @@ internal class OfflineAudioImpl(
     }
 
     object Serializer : KSerializer<OfflineAudioImpl> by Surrogate.serializer().map(
-        resultantDescriptor = Surrogate.serializer().descriptor.copy(OfflineAudio.SERIAL_NAME),
+        resultantDescriptor = Surrogate.serializer().descriptor,
         deserialize = {
             OfflineAudioImpl(
                 filename = filename,

--- a/mirai-core/src/commonMain/kotlin/message/protocol/impl/QuoteReplyProtocol.kt
+++ b/mirai-core/src/commonMain/kotlin/message/protocol/impl/QuoteReplyProtocol.kt
@@ -10,6 +10,7 @@
 package net.mamoe.mirai.internal.message.protocol.impl
 
 import net.mamoe.mirai.contact.AnonymousMember
+import net.mamoe.mirai.internal.message.MessageSourceSerializerImpl
 import net.mamoe.mirai.internal.message.protocol.MessageProtocol
 import net.mamoe.mirai.internal.message.protocol.ProcessorCollector
 import net.mamoe.mirai.internal.message.protocol.decode.MessageDecoder
@@ -24,7 +25,6 @@ import net.mamoe.mirai.internal.message.protocol.serialization.MessageSerializer
 import net.mamoe.mirai.internal.message.source.*
 import net.mamoe.mirai.internal.network.protocol.data.proto.ImMsgBody
 import net.mamoe.mirai.message.data.*
-import net.mamoe.mirai.utils.copy
 import net.mamoe.mirai.utils.map
 
 internal class QuoteReplyProtocol : MessageProtocol(PRIORITY_METADATA) {
@@ -100,7 +100,7 @@ internal class QuoteReplyProtocol : MessageProtocol(PRIORITY_METADATA) {
                 MessageSerializer(
                     MessageSource::class,
                     OfflineMessageSourceImplData.serializer().map(
-                        OfflineMessageSourceImplData.serializer().descriptor.copy(MessageSource.SERIAL_NAME),
+                        MessageSourceSerializerImpl.serialDataSerializer().descriptor,
                         { it },
                         {
                             OfflineMessageSourceImplData(

--- a/mirai-core/src/commonTest/kotlin/message/protocol/impl/MarketFaceProtocolTest.kt
+++ b/mirai-core/src/commonTest/kotlin/message/protocol/impl/MarketFaceProtocolTest.kt
@@ -564,6 +564,11 @@ internal class MarketFaceProtocolTest : AbstractMessageProtocolTest() {
         override val message: Dice
     ) : PolymorphicWrapper
 
+    @Serializable
+    data class StaticWrapperRockPaperScissors(
+        override val message: RockPaperScissors
+    ) : PolymorphicWrapper
+
     private fun <M : MarketFace> testPolymorphicInMarketFace(
         data: M,
         expectedSerialName: String,
@@ -585,6 +590,19 @@ internal class MarketFaceProtocolTest : AbstractMessageProtocolTest() {
         testPolymorphicIn(
             polySerializer = StaticWrapperDice.serializer(),
             polyConstructor = ::StaticWrapperDice,
+            data = data,
+            expectedSerialName = null,
+            expectedInstance = expectedInstance,
+        )
+    })
+
+    private fun testStaticRockPaperScissors(
+        data: RockPaperScissors,
+        expectedInstance: RockPaperScissors = data,
+    ) = listOf(dynamicTest("testStaticRockPaperScissors") {
+        testPolymorphicIn(
+            polySerializer = StaticWrapperRockPaperScissors.serializer(),
+            polyConstructor = ::StaticWrapperRockPaperScissors,
             data = data,
             expectedSerialName = null,
             expectedInstance = expectedInstance,
@@ -614,6 +632,22 @@ internal class MarketFaceProtocolTest : AbstractMessageProtocolTest() {
             testPolymorphicInSingleMessage(data, serialName),
             testInsideMessageChain(data, serialName),
             testContextual(data, serialName, targetType = MarketFace::class),
+        )
+    }
+
+    @TestFactory
+    fun `test serialization for RockPaperScissors`(): DynamicTestsResult {
+        val data = RockPaperScissors.PAPER
+
+        val serialName = RockPaperScissors.SERIAL_NAME
+        return runDynamicTests(
+            testPolymorphicInMarketFace(data, serialName),
+            testPolymorphicInMessageContent(data, serialName),
+            testPolymorphicInSingleMessage(data, serialName),
+            testInsideMessageChain(data, serialName),
+            testContextual(data, serialName),
+            testContextual(data, serialName, targetType = MarketFace::class),
+            testStaticRockPaperScissors(data),
         )
     }
 


### PR DESCRIPTION
根据 kotlin serialization 实现

remapped 的 serializer.descriptor 应该直接使用原本的 descriptior

否则 polymorphic deserialization 会出现 unknown field 'type'

参考:

https://github.com/Kotlin/kotlinx.serialization/blob/33104957873448189eb242413646b58883623e0a/formats/json/commonMain/src/kotlinx/serialization/json/internal/TreeJsonDecoder.kt#L243-L250