### PR TITLE
fix MockNormalMember modify admin

### DIFF
--- a/mirai-core-mock/src/internal/contact/MockGroupImpl.kt
+++ b/mirai-core-mock/src/internal/contact/MockGroupImpl.kt
@@ -108,10 +108,11 @@ internal class MockGroupImpl(
     }
 
     override suspend fun changeOwner(member: NormalMember) {
+        if (member === owner) return
         val oldOwner = owner
         val oldPerm = member.permission
-        member.mock().mockApi.permission = MemberPermission.OWNER
         oldOwner.mock().mockApi.permission = MemberPermission.MEMBER
+        member.mock().mockApi.permission = MemberPermission.OWNER
         owner = member
 
         if (member === botAsMember) {

--- a/mirai-core-mock/src/internal/contact/MockNormalMemberImpl.kt
+++ b/mirai-core-mock/src/internal/contact/MockNormalMemberImpl.kt
@@ -162,7 +162,7 @@ internal class MockNormalMemberImpl(
         val newPerm = if (operation) MemberPermission.ADMINISTRATOR else MemberPermission.MEMBER
         if (newPerm != permission) {
             val oldPerm = permission
-            mockApi.permission = oldPerm
+            mockApi.permission = newPerm
             MemberPermissionChangeEvent(this, oldPerm, newPerm).broadcast()
         }
     }

--- a/mirai-core-mock/test/mock/MockMemberTest.kt
+++ b/mirai-core-mock/test/mock/MockMemberTest.kt
@@ -10,6 +10,7 @@
 package net.mamoe.mirai.mock.test.mock
 
 import net.mamoe.mirai.contact.MemberPermission
+import net.mamoe.mirai.event.events.BotGroupPermissionChangeEvent
 import net.mamoe.mirai.event.events.MemberPermissionChangeEvent
 import net.mamoe.mirai.mock.test.MockBotTestBase
 import net.mamoe.mirai.mock.utils.simpleMemberInfo
@@ -23,6 +24,21 @@ internal class MockMemberTest : MockBotTestBase() {
     internal fun testAvatar() = runTest {
         val m = bot.addGroup(111, "aaa").addMember(simpleMemberInfo(222, "bbb", permission = MemberPermission.MEMBER))
         assertNotEquals("", m.avatarUrl)
+    }
+
+    @Test
+    internal fun changeOwner() = runTest {
+        val group = bot.addGroup(111, "aaa")
+        val member = group.addMember(simpleMemberInfo(222, "bbb", permission = MemberPermission.MEMBER))
+        val events = runAndReceiveEventBroadcast {
+            group.changeOwner(member)
+        }
+        assertEquals(2, events.size)
+        assertTrue {
+            events[0] is MemberPermissionChangeEvent
+                    && events[1] is BotGroupPermissionChangeEvent
+        }
+        assertEquals(MemberPermission.OWNER, member.permission)
     }
 
     @Test

--- a/mirai-core-mock/test/mock/MockMemberTest.kt
+++ b/mirai-core-mock/test/mock/MockMemberTest.kt
@@ -13,6 +13,7 @@ import net.mamoe.mirai.contact.MemberPermission
 import net.mamoe.mirai.mock.test.MockBotTestBase
 import net.mamoe.mirai.mock.utils.simpleMemberInfo
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 internal class MockMemberTest : MockBotTestBase() {
@@ -20,5 +21,14 @@ internal class MockMemberTest : MockBotTestBase() {
     internal fun testAvatar() = runTest {
         val m = bot.addGroup(111, "aaa").addMember(simpleMemberInfo(222, "bbb", permission = MemberPermission.MEMBER))
         assertNotEquals("", m.avatarUrl)
+    }
+
+    @Test
+    internal fun modifyAdmin() = runTest {
+        val m = bot.addGroup(111, "aaa").also {
+            it.botAsMember.mockApi.permission = MemberPermission.OWNER
+        }.addMember(simpleMemberInfo(222, "bbb", permission = MemberPermission.MEMBER))
+        m.modifyAdmin(true)
+        assertEquals(MemberPermission.ADMINISTRATOR, m.permission)
     }
 }


### PR DESCRIPTION
暂时还没测试，因为我跑 MockMemberTest 的时候报错如下:
```
java.lang.ExceptionInInitializerError
	at net.mamoe.mirai.mock.test.MockBotTestBase.<init>(MockBotTestBase.kt:25)
	at net.mamoe.mirai.mock.test.mock.MockMemberTest.<init>(MockMemberTest.kt:19)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at org.junit.platform.commons.util.ReflectionUtils.newInstance(ReflectionUtils.java:513)
	at org.junit.jupiter.engine.execution.ConstructorInvocation.proceed(ConstructorInvocation.java:56)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.api.extension.InvocationInterceptor.interceptTestClassConstructor(InvocationInterceptor.java:72)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:77)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeTestClassConstructor(ClassBasedTestDescriptor.java:342)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateTestClass(ClassBasedTestDescriptor.java:289)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.instantiateTestClass(ClassTestDescriptor.java:79)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateAndPostProcessTestInstance(ClassBasedTestDescriptor.java:267)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$2(ClassBasedTestDescriptor.java:259)
	at java.base/java.util.Optional.orElseGet(Optional.java:362)
	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$3(ClassBasedTestDescriptor.java:258)
	at org.junit.jupiter.engine.execution.TestInstancesProvider.getTestInstances(TestInstancesProvider.java:31)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$prepare$0(TestMethodTestDescriptor.java:101)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:100)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:65)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$1(NodeTestTask.java:111)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:111)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:79)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:57)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.util.NoSuchElementException: Could not find an implementation for service class net.mamoe.mirai.IMirai
	at net.mamoe.mirai.utils.ServicesKt.loadService(Services.kt:21)
	at net.mamoe.mirai.Mirai.findMiraiInstance(IMirai.kt:347)
	at net.mamoe.mirai._MiraiInstance.get(IMirai.kt:338)
	at net.mamoe.mirai.Mirai.getInstance(IMirai.kt:39)
	at net.mamoe.mirai.mock.MockBotFactory.<clinit>(MockBotFactory.kt:52)
	... 70 more
	Suppressed: java.lang.ExceptionInInitializerError
		at net.mamoe.mirai.internal.message.protocol.MessageProtocolFacade.<clinit>(MessageProtocolFacade.kt)
		at net.mamoe.mirai.internal.MiraiImplKt._MiraiImpl_static_init(MiraiImpl.kt:25)
		at net.mamoe.mirai.internal.MiraiImpl.<clinit>(MiraiImpl.kt:94)
		at java.base/java.lang.Class.forName0(Native Method)
		at java.base/java.lang.Class.forName(Class.java:377)
		at net.mamoe.mirai.utils.ServicesKt.findCreateInstance(Services.kt:27)
		at net.mamoe.mirai.utils.ServicesKt.loadService(Services.kt:20)
		... 74 more
	Caused by: java.lang.IllegalStateException: Failed to load services for MessageProtocol from your classpath. Check you ClassLoader environment and ensure services for 'net.mamoe.mirai.internal.message.protocol.MessageProtocol' can be loaded. This should not happen if you are using mirai under default JVM classloader or using Mirai Console.If so, please file an issue. If you are trying to load mirai manually from other classloader, e.g. in another plugin system like Minecraft, it's your responsibility to ensure the Java SPI works.
		at net.mamoe.mirai.internal.message.protocol.MessageProtocolFacadeImpl.<init>(MessageProtocolFacade.kt:208)
		at net.mamoe.mirai.internal.message.protocol.MessageProtocolFacadeImpl.<init>(MessageProtocolFacade.kt:193)
		at net.mamoe.mirai.internal.message.protocol.MessageProtocolFacade$INSTANCE.<init>(MessageProtocolFacade.kt:162)
		at net.mamoe.mirai.internal.message.protocol.MessageProtocolFacade$INSTANCE.<clinit>(MessageProtocolFacade.kt)
		... 81 more
```