### PR TITLE
修复发送消息时实际发送的消息会忽略通过 `MessagePreSendEvent` 所进行的修改

### DIFF
--- a/mirai-core/src/commonMain/kotlin/contact/AbstractUser.kt
+++ b/mirai-core/src/commonMain/kotlin/contact/AbstractUser.kt
@@ -260,7 +260,7 @@ internal suspend fun <C : AbstractContact> C.sendMessageImpl(
     val chain = broadcastMessagePreSendEvent(message, skipEvent, preSendEventConstructor)
 
     val result = kotlin.runCatching {
-        MessageProtocolFacade.preprocessAndSendOutgoing(this, message, buildComponentStorage {
+        MessageProtocolFacade.preprocessAndSendOutgoing(this, chain, buildComponentStorage {
             set(MessageProtocolStrategy, messageProtocolStrategy)
             set(HighwayUploader, HighwayUploader.Default)
             set(ClockHolder, bot.components[ClockHolder])


### PR DESCRIPTION
`MessagePreSendEvent` 的 `message` 属性注释了 `待发送的消息 修改后将会同时应用于发送` 。然而在实际情况下，发送消息时会忽略修改过的消息而使用原消息，所以在此修复。