### PR TITLE
修复使用 Console 扩展时，对于扩展的函数返回非 null 值报错的情况

### DIFF
--- a/mirai-console/backend/mirai-console/src/command/resolve/CommandCallInterceptor.kt
+++ b/mirai-console/backend/mirai-console/src/command/resolve/CommandCallInterceptor.kt
@@ -147,8 +147,8 @@ public inline fun <T, R> InterceptResult<T>.fold(
         callsInPlace(onIntercepted, InvocationKind.AT_MOST_ONCE)
         callsInPlace(otherwise, InvocationKind.AT_MOST_ONCE)
     }
-    value?.let(otherwise)
-    reason?.let(onIntercepted)
+    value?.let { return otherwise(it) }
+    reason?.let { return onIntercepted(it) }
     UNREACHABLE_CLAUSE
 }
 


### PR DESCRIPTION
```
2023-02-24 01:03:20 E/Chat Command: Exception in coroutine Plugin net.mamoe.mirai.console.chat-command of Chat Command
net.mamoe.mirai.console.extension.ExtensionException: Exception while executing extension 'NoMathExpectation.NMEBoot.commands.InterceptingCommandCall' provided by plugin 'NMEBoot', registered for 'net.mamoe.mirai.console.extensions.CommandCallInterceptorProvider'
	at net.mamoe.mirai.console.internal.extension.AbstractConcurrentComponentStorage.throwExtensionException$mirai_console(ComponentStorageInternal.kt:133)
	at net.mamoe.mirai.console.command.resolve.CommandCallInterceptor$Companion.intercepted(CommandCallInterceptor.kt:211)
	at net.mamoe.mirai.console.internal.command.CommandManagerImplKt.executeCommandImpl(CommandManagerImpl.kt:142)
	at net.mamoe.mirai.console.command.CommandManager.executeCommand$suspendImpl(CommandManager.kt:130)
	at net.mamoe.mirai.console.command.CommandManager.executeCommand(CommandManager.kt)
	at net.mamoe.mirai.console.command.CommandManager$INSTANCE.executeCommand(CommandManager.kt)
	at net.mamoe.mirai.console.command.CommandManager.executeCommand$default(CommandManager.kt:125)
	at chat-command-0.5.1.jar//net.mamoe.mirai.console.plugins.chat.command.PluginMain.handleCommand(PluginMain.kt:86)
	at chat-command-0.5.1.jar//net.mamoe.mirai.console.plugins.chat.command.PluginMain$onEnable$2$1.invokeSuspend(PluginMain.kt:69)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
Caused by: java.lang.AssertionError: Reached an unexpected branch.
	at net.mamoe.mirai.console.command.resolve.CommandCallInterceptor$Companion.intercepted(CommandCallInterceptor.kt:209)
	... 13 more
```