### PR TITLE
修复JvmPlugin无法通过自己的classLoader以getResource的方法获取全局依赖的class文件

### DIFF
--- a/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
+++ b/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
@@ -66,5 +66,8 @@ internal object PMain : KotlinPlugin(JvmPluginDescription("net.mamoe.console.ite
         )
         assertNull(javaClass.getResource("/net/mamoe/mirai/console/MiraiConsole.class"))
         assertNull(javaClass.getResource("/net/mamoe/mirai/Bot.class"))
+        this.jvmPluginClasspath.openMiraiDependenciesClassResource = true
+        assertNotNull(javaClass.getResource("/net/mamoe/mirai/console/MiraiConsole.class"))
+        assertNotNull(javaClass.getResource("/net/mamoe/mirai/Bot.class"))
     }
 }

--- a/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
+++ b/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
@@ -17,6 +17,7 @@ import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 
 internal class PS : ServiceTypedef
@@ -91,8 +92,8 @@ internal object PMain : KotlinPlugin(JvmPluginDescription("net.mamoe.console.ite
         assertNotNull(javaClass.classLoader.getResource(miraiConsoleClassPath))
         assertNotNull(javaClass.classLoader.getResource(miraiBotClassPath))
 
-        assert(javaClass.classLoader.getSizeOfResources(miraiConsoleClassPath) > miraiConsoleClassResourceCount)
-        assert(javaClass.classLoader.getSizeOfResources(allClassesPath) > allClassesResourceCount)
+        assertTrue(javaClass.classLoader.getSizeOfResources(miraiConsoleClassPath) > miraiConsoleClassResourceCount)
+        assertTrue(javaClass.classLoader.getSizeOfResources(allClassesPath) > allClassesResourceCount)
 
         jvmPluginClasspath.shouldResolveConsoleSystemResource = false
 

--- a/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
+++ b/mirai-console/backend/integration-test/testers/service-loader/service-loader-2dep-plugin/src/PMain.kt
@@ -66,7 +66,7 @@ internal object PMain : KotlinPlugin(JvmPluginDescription("net.mamoe.console.ite
         )
         assertNull(javaClass.getResource("/net/mamoe/mirai/console/MiraiConsole.class"))
         assertNull(javaClass.getResource("/net/mamoe/mirai/Bot.class"))
-        this.jvmPluginClasspath.openMiraiDependenciesClassResource = true
+        this.jvmPluginClasspath.shouldResolveConsoleSystemResource = true
         assertNotNull(javaClass.getResource("/net/mamoe/mirai/console/MiraiConsole.class"))
         assertNotNull(javaClass.getResource("/net/mamoe/mirai/Bot.class"))
     }

--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -2019,10 +2019,12 @@ public final class net/mamoe/mirai/console/plugin/jvm/JvmPlugin$Companion {
 public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginClasspath {
 	public abstract fun addToPath (Ljava/lang/ClassLoader;Ljava/io/File;)V
 	public abstract fun downloadAndAddToPath (Ljava/lang/ClassLoader;Ljava/util/Collection;)V
+	public abstract fun getOpenMiraiDependenciesClassResource ()Z
 	public abstract fun getPluginClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getPluginFile ()Ljava/io/File;
 	public abstract fun getPluginIndependentLibrariesClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getPluginSharedLibrariesClassLoader ()Ljava/lang/ClassLoader;
+	public abstract fun setOpenMiraiDependenciesClassResource (Z)V
 }
 
 public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginDescription : net/mamoe/mirai/console/plugin/description/PluginDescription {

--- a/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
+++ b/mirai-console/backend/mirai-console/compatibility-validation/jvm/api/jvm.api
@@ -2019,12 +2019,12 @@ public final class net/mamoe/mirai/console/plugin/jvm/JvmPlugin$Companion {
 public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginClasspath {
 	public abstract fun addToPath (Ljava/lang/ClassLoader;Ljava/io/File;)V
 	public abstract fun downloadAndAddToPath (Ljava/lang/ClassLoader;Ljava/util/Collection;)V
-	public abstract fun getOpenMiraiDependenciesClassResource ()Z
 	public abstract fun getPluginClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getPluginFile ()Ljava/io/File;
 	public abstract fun getPluginIndependentLibrariesClassLoader ()Ljava/lang/ClassLoader;
 	public abstract fun getPluginSharedLibrariesClassLoader ()Ljava/lang/ClassLoader;
-	public abstract fun setOpenMiraiDependenciesClassResource (Z)V
+	public abstract fun getShouldResolveConsoleSystemResource ()Z
+	public abstract fun setShouldResolveConsoleSystemResource (Z)V
 }
 
 public abstract interface class net/mamoe/mirai/console/plugin/jvm/JvmPluginDescription : net/mamoe/mirai/console/plugin/description/PluginDescription {

--- a/mirai-console/backend/mirai-console/src/internal/plugin/AllDependenciesClassesHolder.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/AllDependenciesClassesHolder.kt
@@ -22,11 +22,5 @@ internal object AllDependenciesClassesHolder {
         }
 
     @JvmField
-    internal val allClassesAsResources =
-        allclasses
-            .map { it.replace('.', '/') + ".class" }
-            .toHashSet()
-
-    @JvmField
     internal val appClassLoader: ClassLoader = AllDependenciesClassesHolder::class.java.classLoader
 }

--- a/mirai-console/backend/mirai-console/src/internal/plugin/AllDependenciesClassesHolder.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/AllDependenciesClassesHolder.kt
@@ -22,5 +22,11 @@ internal object AllDependenciesClassesHolder {
         }
 
     @JvmField
+    internal val allClassesAsResources =
+        allclasses
+            .map { it.replace('.', '/') + ".class" }
+            .toHashSet()
+
+    @JvmField
     internal val appClassLoader: ClassLoader = AllDependenciesClassesHolder::class.java.classLoader
 }

--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
@@ -484,7 +484,9 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
 
         val resolved = LinkedHashSet<URL>()
 
-        DynLibClassLoader.tryFastOrStrictResolveResources(name).let { resolved.addAll(it) }
+        if (openaccess.openMiraiDependenciesClassResource) {
+            DynLibClassLoader.tryFastOrStrictResolveResources(name).let { resolved.addAll(it) }
+        }
         src.forEach { nested -> resolved.addAll(nested) }
 
         return Collections.enumeration(resolved)
@@ -510,9 +512,11 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
         if (name.startsWith("META-INF/services/net.mamoe.mirai.console.plugin."))
             return findResource(name)
 
-        DynLibClassLoader.tryFastOrStrictResolveResources(name)
-            .takeIf { it.hasMoreElements() }
-            ?.let { return it.nextElement() }
+        if (openaccess.openMiraiDependenciesClassResource) {
+            DynLibClassLoader.tryFastOrStrictResolveResources(name)
+                .takeIf { it.hasMoreElements() }
+                ?.let { return it.nextElement() }
+        }
 
         findResource(name)?.let { return it }
         // parent: ctx.sharedLibrariesLoader
@@ -538,6 +542,8 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
             get() = pluginSharedCL
         override val pluginIndependentLibrariesClassLoader: ClassLoader
             get() = pluginIndependentCL
+
+        override var openMiraiDependenciesClassResource: Boolean = false
 
         private val permitted by lazy {
             arrayOf(

--- a/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
+++ b/mirai-console/backend/mirai-console/src/internal/plugin/JvmPluginClassLoader.kt
@@ -484,7 +484,7 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
 
         val resolved = LinkedHashSet<URL>()
 
-        if (openaccess.openMiraiDependenciesClassResource) {
+        if (openaccess.shouldResolveConsoleSystemResource) {
             DynLibClassLoader.tryFastOrStrictResolveResources(name).let { resolved.addAll(it) }
         }
         src.forEach { nested -> resolved.addAll(nested) }
@@ -512,7 +512,7 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
         if (name.startsWith("META-INF/services/net.mamoe.mirai.console.plugin."))
             return findResource(name)
 
-        if (openaccess.openMiraiDependenciesClassResource) {
+        if (openaccess.shouldResolveConsoleSystemResource) {
             DynLibClassLoader.tryFastOrStrictResolveResources(name)
                 .takeIf { it.hasMoreElements() }
                 ?.let { return it.nextElement() }
@@ -543,7 +543,7 @@ internal class JvmPluginClassLoaderN : URLClassLoader {
         override val pluginIndependentLibrariesClassLoader: ClassLoader
             get() = pluginIndependentCL
 
-        override var openMiraiDependenciesClassResource: Boolean = false
+        override var shouldResolveConsoleSystemResource: Boolean = false
 
         private val permitted by lazy {
             arrayOf(

--- a/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
+++ b/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
@@ -42,6 +42,14 @@ public interface JvmPluginClasspath {
     public val pluginIndependentLibrariesClassLoader: ClassLoader
 
     /**
+     * 是否允许Mirai的公共依赖（如Mirai本身、slf4j等）的字节码文件（.class）作为资源
+     * 被[pluginClassLoader]通过[ClassLoader.getResource]等方式加载
+     *
+     * 默认为 `false`
+     */
+    public var openMiraiDependenciesClassResource: Boolean
+
+    /**
      * 将 [file] 加入 [classLoader] 的搜索路径内
      *
      * @throws IllegalArgumentException 当 [classLoader] 不是 [pluginClassLoader],

--- a/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
+++ b/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
@@ -42,12 +42,12 @@ public interface JvmPluginClasspath {
     public val pluginIndependentLibrariesClassLoader: ClassLoader
 
     /**
-     * 是否允许Mirai的公共依赖（如Mirai本身、slf4j等）的字节码文件（.class）作为资源
-     * 被[pluginClassLoader]通过[ClassLoader.getResource]等方式加载
+     * 是否允许 Mirai 的公共依赖（如 Mirai 本身、SLF4J 等）的字节码文件（.class）作为资源被
+     * [pluginClassLoader] 通过 [ClassLoader.getResource] 等方式加载
      *
      * 默认为 `false`
      */
-    public var openMiraiDependenciesClassResource: Boolean
+    public var shouldResolveConsoleSystemResource: Boolean
 
     /**
      * 将 [file] 加入 [classLoader] 的搜索路径内

--- a/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
+++ b/mirai-console/backend/mirai-console/src/plugin/jvm/JvmPluginClasspath.kt
@@ -42,8 +42,7 @@ public interface JvmPluginClasspath {
     public val pluginIndependentLibrariesClassLoader: ClassLoader
 
     /**
-     * 是否允许 Mirai 的公共依赖（如 Mirai 本身、SLF4J 等）的字节码文件（.class）作为资源被
-     * [pluginClassLoader] 通过 [ClassLoader.getResource] 等方式加载
+     * [pluginClassLoader] 是否可以通过 [ClassLoader.getResource] 获取 Mirai Console (包括依赖) 的相关资源
      *
      * 默认为 `false`
      */

--- a/mirai-core-utils/src/jvmBaseMain/kotlin/Collections.kt
+++ b/mirai-core-utils/src/jvmBaseMain/kotlin/Collections.kt
@@ -55,3 +55,17 @@ public actual fun <K : Enum<K>, V> EnumMap(clazz: KClass<K>): MutableMap<K, V> {
 public actual fun <E> ConcurrentSet(): MutableSet<E> {
     return CopyOnWriteArraySet()
 }
+
+/**
+ * Same as [MutableCollection.addAll].
+ *
+ * Adds all the elements of the specified enumeration to this collection.
+ * @return true if any of the specified elements was added to the collection, false if the collection was not modified.
+ */
+public fun <T> MutableCollection<T>.addAll(enumeration: Enumeration<T>): Boolean {
+    var addResult = false
+    while (enumeration.hasMoreElements()) {
+        addResult = this.add(enumeration.nextElement())
+    }
+    return addResult
+}


### PR DESCRIPTION
fix #2535
原本JvmPlugin的classLoader可以正确地加载到全局依赖的Class对象，但无法通过getResource方法获取到其class文件。