### PR TITLE
修复 dumpTlvMap 不正确的返回值

### DIFF
--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
@@ -247,7 +247,7 @@ internal class WtLogin {
         }
 
         private fun dumpTlvMap(tlvMap: TlvMap): String {
-            return tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}"
+            return tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}" }
         }
 
         private fun onDevLockLogin(

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
@@ -246,9 +246,7 @@ internal class WtLogin {
             }
         }
 
-        private fun dumpTlvMap(tlvMap: TlvMap) {
-            tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}" }
-        }
+        private fun dumpTlvMap(tlvMap: TlvMap): String = tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}" }
 
         private fun onDevLockLogin(
             tlvMap: TlvMap,

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/login/WtLogin.kt
@@ -246,7 +246,9 @@ internal class WtLogin {
             }
         }
 
-        private fun dumpTlvMap(tlvMap: TlvMap): String = tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}" }
+        private fun dumpTlvMap(tlvMap: TlvMap): String {
+            return tlvMap.entries.joinToString { "${it.key}=${it.value.toUHexString()}"
+        }
 
         private fun onDevLockLogin(
             tlvMap: TlvMap,


### PR DESCRIPTION
#2555 `TLVMap = kotlin.Unit`