### PR TITLE
增加 TxCaptchaHelper 可用性无法保证的警告

### DIFF
--- a/mirai-core-api/src/jvmMain/kotlin/utils/LoginSolver.jvm.kt
+++ b/mirai-core-api/src/jvmMain/kotlin/utils/LoginSolver.jvm.kt
@@ -1,4 +1,4 @@
-/*
+*/*
  * Copyright 2019-2022 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
@@ -105,6 +105,9 @@ public class StandardCharImageLoginSolver @JvmOverloads constructor(
         logger.info { "[SliderCaptcha] @see https://docs.mirai.mamoe.net/mirai-login-solver-selenium/" }
         logger.info { "[SliderCaptcha] 或者输入 TxCaptchaHelper 来使用 TxCaptchaHelper 完成滑动验证码" }
         logger.info { "[SliderCaptcha] Or type `TxCaptchaHelper` to resolve slider captcha with TxCaptchaHelper.apk" }
+        logger.warning { "[SliderCaptcha] TxCaptchaHelper 的在线服务疑似被屏蔽，可能无法使用。TxCaptchaHelper 现已无法满足登录QQ机器人，请在以下链接下载全新的验证器" }
+        logger.warning { "[SliderCaptcha] The service of `TxCaptchaHelper` might be blocked. We recommend you to download the new login solver plugin in below link." }
+        logger.warning { "[SliderCaptcha] @see https://github.com/KasukuSakura/mirai-login-solver-sakura" }
         logger.info { "[SliderCaptcha] Captcha link: $url" }
 
         suspend fun runTxCaptchaHelper(): String {

--- a/mirai-core-api/src/jvmMain/kotlin/utils/LoginSolver.jvm.kt
+++ b/mirai-core-api/src/jvmMain/kotlin/utils/LoginSolver.jvm.kt
@@ -1,4 +1,4 @@
-*/*
+/*
  * Copyright 2019-2022 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.


### PR DESCRIPTION
我的交流群里每隔一段时间就有人问为什么连接超时，其中用 console 的有，用 core 的也有。不是所有人都能第一时间翻到论坛公告，个人认为有必要加一个警告。