### PR TITLE
Fix token not saving after refresh token

### DIFF
--- a/mirai-core/src/commonMain/kotlin/network/components/KeyRefreshProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/components/KeyRefreshProcessor.kt
@@ -67,5 +67,8 @@ internal class KeyRefreshProcessorImpl(
 
     override suspend fun refreshKeysNow(handler: NetworkHandler) {
         handler.sendAndExpect(WtLogin15(handler.context[SsoProcessor].client))
+        handler.context[SsoProcessor].client.bot.apply {
+            components[AccountSecretsManager].saveSecrets(account, AccountSecretsImpl(client))
+        }
     }
 }

--- a/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.SidExpired.kt
+++ b/mirai-core/src/commonMain/kotlin/network/protocol/packet/chat/receive/OnlinePush.SidExpired.kt
@@ -12,6 +12,8 @@ package net.mamoe.mirai.internal.network.protocol.packet.chat.receive
 import io.ktor.utils.io.core.*
 import net.mamoe.mirai.internal.QQAndroidBot
 import net.mamoe.mirai.internal.network.Packet
+import net.mamoe.mirai.internal.network.components.AccountSecretsImpl
+import net.mamoe.mirai.internal.network.components.AccountSecretsManager
 import net.mamoe.mirai.internal.network.protocol.packet.IncomingPacketFactory
 import net.mamoe.mirai.internal.network.protocol.packet.OutgoingPacket
 import net.mamoe.mirai.internal.network.protocol.packet.buildResponseUniPacket
@@ -23,6 +25,7 @@ internal object OnlinePushSidExpired :
     override suspend fun QQAndroidBot.handle(packet: Packet?, sequenceId: Int): OutgoingPacket {
         return buildResponseUniPacket(client, sequenceId = sequenceId).also {
             bot.network.sendAndExpect(WtLogin10(client, mainSigMap = 1052896, remark = "10:refresh-token"))
+            bot.components[AccountSecretsManager].saveSecrets(bot.account, AccountSecretsImpl(client))
         }
     }
 


### PR DESCRIPTION
It’s a bug for looong times lol, but should only affect after complete restart mirai or renew bot