### PR TITLE
[idea] feat: generate gradle-wrapper.properties and src/test directory

### DIFF
--- a/mirai-console/tools/intellij-plugin/resources/fileTemplates/code/Gradle gradle-wrapper.properties.ft
+++ b/mirai-console/tools/intellij-plugin/resources/fileTemplates/code/Gradle gradle-wrapper.properties.ft
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/mirai-console/tools/intellij-plugin/resources/fileTemplates/code/Gradle gradle-wrapper.properties.html
+++ b/mirai-console/tools/intellij-plugin/resources/fileTemplates/code/Gradle gradle-wrapper.properties.html
@@ -1,0 +1,14 @@
+<!--
+  ~ Copyright 2019-2023 Mamoe Technologies and contributors.
+  ~
+  ~ 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+  ~ Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
+  ~
+  ~ https://github.com/mamoe/mirai/blob/dev/LICENSE
+  -->
+
+<html>
+<body>
+<p>This is a built-in file template used to create a new gradle-wrapper.properties for Mirai Console Plugin projects.</p>
+</body>
+</html>

--- a/mirai-console/tools/intellij-plugin/src/assets/Assets.kt
+++ b/mirai-console/tools/intellij-plugin/src/assets/Assets.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Mamoe Technologies and contributors.
+ * Copyright 2019-2023 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
@@ -26,6 +26,7 @@ object FT { // file template
     const val SettingsGradleKts = "Plugin settings.gradle.kts"
     const val SettingsGradle = "Plugin settings.gradle"
 
+    const val GradleWrapperProperties = "Gradle gradle-wrapper.properties"
     const val GradleProperties = "Gradle gradle.properties"
 
     const val PluginMainKt = "Plugin main class Kotlin.kt"

--- a/mirai-console/tools/intellij-plugin/src/assets/FileTemplateRegistrar.kt
+++ b/mirai-console/tools/intellij-plugin/src/assets/FileTemplateRegistrar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Mamoe Technologies and contributors.
+ * Copyright 2019-2023 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
@@ -23,6 +23,7 @@ class FileTemplateRegistrar : com.intellij.ide.fileTemplates.FileTemplateGroupDe
             addTemplate(FileTemplateDescriptor(FT.PluginMainJava))
             addTemplate(FileTemplateDescriptor(FT.PluginMainService))
 
+            addTemplate(FileTemplateDescriptor(FT.GradleWrapperProperties))
             addTemplate(FileTemplateDescriptor(FT.GradleProperties))
 
             addTemplate(FileTemplateDescriptor(FT.SettingsGradleKts))

--- a/mirai-console/tools/intellij-plugin/src/wizard/MiraiModuleBuilder.kt
+++ b/mirai-console/tools/intellij-plugin/src/wizard/MiraiModuleBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Mamoe Technologies and contributors.
+ * Copyright 2019-2023 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
@@ -108,6 +108,10 @@ class MiraiModuleBuilder : StarterModuleBuilder() {
         val model = starterContext.getUserData(MIRAI_PROJECT_MODEL_KEY)!!
 
         val standardAssetsProvider = StandardAssetsProvider()
+        assets.add(GeneratorTemplateFile(
+            standardAssetsProvider.gradleWrapperPropertiesLocation,
+            ftManager.getCodeTemplate(FT.GradleWrapperProperties)
+        ))
         assets.addAll(standardAssetsProvider.getGradlewAssets())
 
         model.buildSystemType.createBuildSystem(model)

--- a/mirai-console/tools/intellij-plugin/src/wizard/ProjectAssetsProvider.kt
+++ b/mirai-console/tools/intellij-plugin/src/wizard/ProjectAssetsProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Mamoe Technologies and contributors.
+ * Copyright 2019-2023 Mamoe Technologies and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license that can be found through the following link.
@@ -38,6 +38,9 @@ sealed class GradleProjectCreator(
     ) {
         collect(GeneratorEmptyDirectory("src/main/${model.languageType.sourceSetDirName}"))
         collect(GeneratorEmptyDirectory("src/main/resources"))
+
+        collect(GeneratorEmptyDirectory("src/test/${model.languageType.sourceSetDirName}"))
+        collect(GeneratorEmptyDirectory("src/test/resources"))
 
         collect(GeneratorTemplateFile(model.languageType.pluginMainClassFile(this)))
 


### PR DESCRIPTION
使插件在新建项目时创建`gradle-wrapper.properties`文件和`src/test`文件夹

Closes #2617 