### PR TITLE
fix:  digest message

### DIFF
--- a/mirai-core/src/commonMain/kotlin/contact/essence/EssencesImpl.kt
+++ b/mirai-core/src/commonMain/kotlin/contact/essence/EssencesImpl.kt
@@ -79,8 +79,8 @@ internal class EssencesImpl(
 
     private suspend fun source(digests: DigestMessage, parse: Boolean): MessageSource {
         return group.bot.buildMessageSource(MessageSourceKind.GROUP) {
-            ids = intArrayOf(digests.msgSeq)
-            internalIds = intArrayOf(digests.msgRandom)
+            ids = intArrayOf(digests.msgSeq.toInt())
+            internalIds = intArrayOf(digests.msgRandom.toInt())
             time = digests.senderTime
 
             fromId = digests.senderUin
@@ -122,8 +122,8 @@ internal class EssencesImpl(
     override suspend fun share(source: MessageSource): String {
         val share = group.bot.shareDigest(
             groupCode = group.id,
-            msgSeq = source.ids.first(),
-            msgRandom = source.internalIds.first(),
+            msgSeq = source.ids.first().toLong().and(0xFFFF_FFFF),
+            msgRandom = source.internalIds.first().toLong().and(0xFFFF_FFFF),
             targetGroupCode = 0
         )
         return "https://qun.qq.com/essence/share?_wv=3&_wwv=128&_wvx=2&sharekey=${share.shareKey}"
@@ -143,8 +143,8 @@ internal class EssencesImpl(
             try {
                 group.bot.cancelDigest(
                     groupCode = group.id,
-                    msgSeq = source.ids.first(),
-                    msgRandom = source.internalIds.first()
+                    msgSeq = source.ids.first().toLong().and(0xFFFF_FFFF),
+                    msgRandom = source.internalIds.first().toLong().and(0xFFFF_FFFF)
                 )
             } catch (cause: IllegalStateException) {
                 cause.addSuppressed(IllegalStateException(result.msg))

--- a/mirai-core/src/commonMain/kotlin/contact/essence/GroupDigestProtocol.kt
+++ b/mirai-core/src/commonMain/kotlin/contact/essence/GroupDigestProtocol.kt
@@ -60,9 +60,9 @@ internal data class DigestMessage(
     @SerialName("msg_content")
     val msgContent: List<JsonObject> = emptyList(),
     @SerialName("msg_random")
-    val msgRandom: Int = 0,
+    val msgRandom: Long = 0,
     @SerialName("msg_seq")
-    val msgSeq: Int = 0,
+    val msgSeq: Long = 0,
     @SerialName("sender_nick")
     val senderNick: String = "",
     @SerialName("sender_time")
@@ -108,7 +108,7 @@ internal suspend fun QQAndroidBot.getDigestList(
 }
 
 internal suspend fun QQAndroidBot.cancelDigest(
-    groupCode: Long, msgSeq: Int, msgRandom: Int
+    groupCode: Long, msgSeq: Long, msgRandom: Long
 ) {
     val data = components[HttpClientProvider].getHttpClient().get {
         url("https://qun.qq.com/cgi-bin/group_digest/cancel_digest")
@@ -133,7 +133,7 @@ internal suspend fun QQAndroidBot.cancelDigest(
 }
 
 internal suspend fun QQAndroidBot.shareDigest(
-    groupCode: Long, msgSeq: Int, msgRandom: Int, targetGroupCode: Long
+    groupCode: Long, msgSeq: Long, msgRandom: Long, targetGroupCode: Long
 ): DigestShare {
     return components[HttpClientProvider].getHttpClient().get {
         url("https://qun.qq.com/cgi-bin/group_digest/share_digest")


### PR DESCRIPTION
精华消息 API 使用 unsigned int 作为 msgSeq 和 msgRandom 的数据类型

close #2668 