### PR TITLE
fix wrong publish of androidRelease

### DIFF
--- a/buildSrc/src/main/kotlin/Android.kt
+++ b/buildSrc/src/main/kotlin/Android.kt
@@ -174,7 +174,7 @@ private fun Project.configureAndroidTargetWithSdk(androidNamespace: String) {
             targetCompatibility = JavaVersion.VERSION_1_8
         }
         buildTypes.getByName("release") {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
将 isMinifyEnabled 设为 false，发布到本地的 mirai-core-androidRelease 大小为 13MB，反之为 3KB，可以确定是这个选项的问题了。

fix #2697