### PR TITLE
[core]修复从可确定图片类型的字符串组成的mirai code构造的图片type为UNKNOW或与期望类型不一致

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -324,6 +324,9 @@ public interface Image : Message, MessageContent, CodableMessage {
 
 
         public fun build(): Image {
+            // 创建之前确定类型
+            type = ImageType.match(imageId.split(".").last())
+            // isEmoji字段能确定吗
             @OptIn(MiraiInternalApi::class)
             return InternalImageProtocol.instance.createImage(
                 imageId = imageId,
@@ -508,7 +511,8 @@ public enum class ImageType(
 
     //WEBP, //Unsupported by pc client
     APNG("png"),
-    UNKNOWN("gif"); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
+    // 这里既然是未知格式，空串会不会好点，返回gif会可能造成歧义
+    UNKNOWN(""); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
 
     public companion object {
         private val IMAGE_TYPE_ENUM_LIST = values()

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -306,7 +306,7 @@ public interface Image : Message, MessageContent, CodableMessage {
          * @see Image.imageType
          */
         public var type: ImageType = ImageType.UNKNOWN
-
+            get() = if(field == ImageType.UNKNOWN) ImageType.match(imageId.split(".").last()) else field
         /**
          * @see Image.width
          */
@@ -324,9 +324,6 @@ public interface Image : Message, MessageContent, CodableMessage {
 
 
         public fun build(): Image {
-            // 创建之前确定类型
-            type = ImageType.match(imageId.split(".").last())
-            // isEmoji字段能确定吗
             @OptIn(MiraiInternalApi::class)
             return InternalImageProtocol.instance.createImage(
                 imageId = imageId,
@@ -511,8 +508,7 @@ public enum class ImageType(
 
     //WEBP, //Unsupported by pc client
     APNG("png"),
-    // 这里既然是未知格式，空串会不会好点，返回gif会可能造成歧义
-    UNKNOWN(""); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
+    UNKNOWN("gif"); // bad design, should use `null` to represent unknown, but we cannot change it anymore.
 
     public companion object {
         private val IMAGE_TYPE_ENUM_LIST = values()

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -323,7 +323,9 @@ public interface Image : Message, MessageContent, CodableMessage {
 
 
         public fun build(): Image {
-            if(type == ImageType.UNKNOWN) type = ImageType.match(imageId.split(".").last())
+            if (type == ImageType.UNKNOWN) {
+                type = ImageType.match(imageId.split(".").last())
+            }
             @OptIn(MiraiInternalApi::class)
             return InternalImageProtocol.instance.createImage(
                 imageId = imageId,

--- a/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
+++ b/mirai-core-api/src/commonMain/kotlin/message/data/Image.kt
@@ -306,7 +306,6 @@ public interface Image : Message, MessageContent, CodableMessage {
          * @see Image.imageType
          */
         public var type: ImageType = ImageType.UNKNOWN
-            get() = if(field == ImageType.UNKNOWN) ImageType.match(imageId.split(".").last()) else field
         /**
          * @see Image.width
          */
@@ -324,6 +323,7 @@ public interface Image : Message, MessageContent, CodableMessage {
 
 
         public fun build(): Image {
+            if(type == ImageType.UNKNOWN) type = ImageType.match(imageId.split(".").last())
             @OptIn(MiraiInternalApi::class)
             return InternalImageProtocol.instance.createImage(
                 imageId = imageId,

--- a/mirai-core/src/commonTest/kotlin/message/ImageBuilderTest.kt
+++ b/mirai-core/src/commonTest/kotlin/message/ImageBuilderTest.kt
@@ -19,6 +19,10 @@ import kotlin.test.assertEquals
 internal class ImageBuilderTest : AbstractTest() {
     companion object {
         private const val IMAGE_ID = "{01E9451B-70ED-EAE3-B37C-101F1EEBF5B5}.jpg"
+        private const val IMAGE_ID_PNG = "{01E9451B-70ED-EAE3-B37C-101F1EEBF5B5}.png"
+        private const val IMAGE_ID_BMP = "{01E9451B-70ED-EAE3-B37C-101F1EEBF5B5}.bmp"
+        private const val IMAGE_ID_GIF = "{01E9451B-70ED-EAE3-B37C-101F1EEBF5B5}.gif"
+        private const val IMAGE_ID_UNKNOW = "/01E9451B-70ED-EAE3-B37C-101F1EEBF5B5"
     }
 
     @Test
@@ -30,7 +34,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, type)
+            assertEquals(ImageType.JPG, type)
             assertEquals(false, isEmoji)
         }
 
@@ -39,7 +43,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, type)
+            assertEquals(ImageType.JPG, type)
             assertEquals(false, isEmoji)
         }
 
@@ -48,7 +52,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, type)
+            assertEquals(ImageType.JPG, type)
             assertEquals(false, isEmoji)
         }
 
@@ -57,7 +61,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, imageType)
+            assertEquals(ImageType.JPG, imageType)
             assertEquals(false, isEmoji)
         }
     }
@@ -71,7 +75,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, imageType)
+            assertEquals(ImageType.JPG, imageType)
             assertEquals(false, isEmoji)
         }
         Image.fromId(IMAGE_ID).run {
@@ -79,11 +83,43 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.UNKNOWN, imageType)
+            assertEquals(ImageType.JPG, imageType)
             assertEquals(false, isEmoji)
         }
         Image(IMAGE_ID).run {
             assertEquals(IMAGE_ID, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.JPG, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image(IMAGE_ID_PNG).run {
+            assertEquals(IMAGE_ID_PNG, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.PNG, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image(IMAGE_ID_BMP).run {
+            assertEquals(IMAGE_ID_BMP, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.BMP, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image(IMAGE_ID_GIF).run {
+            assertEquals(IMAGE_ID_GIF, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.GIF, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image(IMAGE_ID_UNKNOW).run {
+            assertEquals(IMAGE_ID_UNKNOW, imageId)
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)

--- a/mirai-core/src/commonTest/kotlin/message/ImageBuilderTest.kt
+++ b/mirai-core/src/commonTest/kotlin/message/ImageBuilderTest.kt
@@ -34,7 +34,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.JPG, type)
+            assertEquals(ImageType.UNKNOWN, type)
             assertEquals(false, isEmoji)
         }
 
@@ -43,7 +43,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.JPG, type)
+            assertEquals(ImageType.UNKNOWN, type)
             assertEquals(false, isEmoji)
         }
 
@@ -52,7 +52,7 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, width)
             assertEquals(0, height)
             assertEquals(0, size)
-            assertEquals(ImageType.JPG, type)
+            assertEquals(ImageType.UNKNOWN, type)
             assertEquals(false, isEmoji)
         }
 
@@ -67,25 +67,7 @@ internal class ImageBuilderTest : AbstractTest() {
     }
 
     @Test
-    fun legacyMethods() {
-        // just make sure they work
-
-        Mirai.createImage(IMAGE_ID).run {
-            assertEquals(IMAGE_ID, imageId)
-            assertEquals(0, width)
-            assertEquals(0, height)
-            assertEquals(0, size)
-            assertEquals(ImageType.JPG, imageType)
-            assertEquals(false, isEmoji)
-        }
-        Image.fromId(IMAGE_ID).run {
-            assertEquals(IMAGE_ID, imageId)
-            assertEquals(0, width)
-            assertEquals(0, height)
-            assertEquals(0, size)
-            assertEquals(ImageType.JPG, imageType)
-            assertEquals(false, isEmoji)
-        }
+    fun imageType() {
         Image(IMAGE_ID).run {
             assertEquals(IMAGE_ID, imageId)
             assertEquals(0, width)
@@ -124,6 +106,36 @@ internal class ImageBuilderTest : AbstractTest() {
             assertEquals(0, height)
             assertEquals(0, size)
             assertEquals(ImageType.UNKNOWN, imageType)
+            assertEquals(false, isEmoji)
+        }
+    }
+
+    @Test
+    fun legacyMethods() {
+        // just make sure they work
+
+        Mirai.createImage(IMAGE_ID).run {
+            assertEquals(IMAGE_ID, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.JPG, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image.fromId(IMAGE_ID).run {
+            assertEquals(IMAGE_ID, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.JPG, imageType)
+            assertEquals(false, isEmoji)
+        }
+        Image(IMAGE_ID).run {
+            assertEquals(IMAGE_ID, imageId)
+            assertEquals(0, width)
+            assertEquals(0, height)
+            assertEquals(0, size)
+            assertEquals(ImageType.JPG, imageType)
             assertEquals(false, isEmoji)
         }
         Image(IMAGE_ID) {

--- a/mirai-core/src/commonTest/kotlin/message/protocol/impl/LongMessageProtocolTest.kt
+++ b/mirai-core/src/commonTest/kotlin/message/protocol/impl/LongMessageProtocolTest.kt
@@ -76,7 +76,7 @@ internal class LongMessageProtocolTest : AbstractMessageProtocolTest() {
                             <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
                             <msg serviceID="35" templateID="1" action="viewMultiMsg"
                                  brief="testqGnJ1R..."
-                                 m_resid="(size=1)DBD2AB20196EEB631C95DEF40E20C709"
+                                 m_resid="(size=1)6C6FD4AEC362AA8E54058A27B422FA42"
                                  m_fileName="160023" sourceMsgId="0" url=""
                                  flag="3" adverSign="0" multiMsgFlag="1">
                                 <item layout="1">
@@ -86,7 +86,7 @@ internal class LongMessageProtocolTest : AbstractMessageProtocolTest() {
                                 </item>
                                 <source name="聊天记录" icon="" action="" appid="-1"/>
                             </msg>
-                """.trimIndent(), "(size=1)DBD2AB20196EEB631C95DEF40E20C709"
+                """.trimIndent(), "(size=1)6C6FD4AEC362AA8E54058A27B422FA42"
                     ) + IgnoreLengthCheck + ForceAsLongMessage, context.currentMessageChain
                 )
             }


### PR DESCRIPTION
fix #2760 