### PR TITLE
[core] 修复 `NormalMember.specialTitle` 注释中 `@see` 的错误关联显示，并完善注释

### DIFF
--- a/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
@@ -58,7 +58,7 @@ public interface NormalMember : Member {
      *
      * @see MemberSpecialTitleChangeEvent  成员群特殊头衔改动事件.
      * @throws PermissionDeniedException 无权限修改时
-     * @suppress 试图修改为空字符串将不会产生空头衔的效果，此时成员实际佩戴头衔将退回为[活跃度相关头衔][Member.active]或管理员头衔.
+     * @suppress 请勿试图修改其为空字符串来产生空头衔效果，这将使成员实际佩戴头衔退回为[活跃度相关头衔][Member.active]或管理员头衔.
      */
     public override var specialTitle: String
 

--- a/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
+++ b/mirai-core-api/src/commonMain/kotlin/contact/NormalMember.kt
@@ -56,8 +56,9 @@ public interface NormalMember : Member {
      *
      * 在修改时将会异步上传至服务器.
      *
-     * @see MemberSpecialTitleChangeEvent 群特殊头衔被管理员, 自己或 [Bot] 改动事件. 修改时也会触发此事件.
+     * @see MemberSpecialTitleChangeEvent  成员群特殊头衔改动事件.
      * @throws PermissionDeniedException 无权限修改时
+     * @suppress 试图修改为空字符串将不会产生空头衔的效果，此时成员实际佩戴头衔将退回为[活跃度相关头衔][Member.active]或管理员头衔.
      */
     public override var specialTitle: String
 


### PR DESCRIPTION
1.原注释@see似乎错误的关联显示了[Bot]
![image](https://github.com/mamoe/mirai/assets/76583155/0696bb7a-886b-4057-99e1-f38b3d8085f4)

2.补充了尝试修改特殊头衔为空字符串时会发生的情况注释

