### PR TITLE
[console] fix: 修复跨年时日志文件名日期错乱问题

### DIFF
--- a/mirai-console/frontend/mirai-console-frontend-base/src/logging/LogRecorder.kt
+++ b/mirai-console/frontend/mirai-console-frontend-base/src/logging/LogRecorder.kt
@@ -107,7 +107,7 @@ public open class DailySplitLogRecorder(
     protected val directory: Path,
     protected val base: FrontendBase,
     protected val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern(
-        "YYYY-MM-dd'.log'"
+        "yyyy-MM-dd'.log'"
     ),
 ) : LogRecorder() {
     @JvmField


### PR DESCRIPTION
#2829 

在 `DailySplitLogRecorder` 中，日期格式化使用了大写的 `YYYY`，但正确的应该是小写的 `yyyy`。因为在 `DateTimeFormatter` 中，`yyyy` 表示年份，而 `YYYY` 表示一周中的年份。在使用大写 `YYYY`  的情况下，只要本周跨年，那么这周就算入下一年。这导致了在跨年的情况下会出现日志错乱的问题。

一个简单的例子如下：

```kt
import java.time.LocalDate
import java.time.format.DateTimeFormatter

fun main() {
    val date = LocalDate.of(2023, 12, 31)
    val formatterYYYY = DateTimeFormatter.ofPattern("YYYY-MM-dd")
    val formatteryyyy = DateTimeFormatter.ofPattern("yyyy-MM-dd")
    println(date.format(formatterYYYY))
    println(date.format(formatteryyyy))
}
```

输出：

```
2024-12-31 // 2023 年的最后一天被分配到 2024 周
2023-12-31 // 普通的年，这是正确的
```

摘自 [docs.oracle.com](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)

```
  Symbol  Meaning                     Presentation      Examples
  ------  -------                     ------------      -------
   y       year-of-era                 year              2004; 04
   Y       week-based-year             year              1996; 96
```