### PR TITLE
修复 Timeout waiting for ConfigPush. 掉线问题

### DIFF
--- a/mirai-core/src/commonMain/kotlin/network/components/ConfigPushProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/components/ConfigPushProcessor.kt
@@ -16,6 +16,7 @@ import net.mamoe.mirai.event.globalEventChannel
 import net.mamoe.mirai.event.nextEvent
 import net.mamoe.mirai.internal.network.component.ComponentKey
 import net.mamoe.mirai.internal.network.handler.NetworkHandler
+import net.mamoe.mirai.internal.network.handler.selector.NetworkException
 import net.mamoe.mirai.internal.network.protocol.packet.login.ConfigPushSvc
 import net.mamoe.mirai.utils.MiraiLogger
 import net.mamoe.mirai.utils.warning
@@ -42,7 +43,7 @@ internal class ConfigPushProcessorImpl(
         if (resp == null) {
             val bdhSyncer = network.context[BdhSessionSyncer]
             if (!bdhSyncer.hasSession) {
-                val e = IllegalStateException("Timeout waiting for ConfigPush.")
+                val e = NetworkException("Timeout waiting for ConfigPush.",true)
                 bdhSyncer.bdhSession.completeExceptionally(e)
                 logger.warning { "Missing ConfigPush. Switching server..." }
                 network.context[SsoProcessor].casFirstLoginResult(null, FirstLoginResult.CHANGE_SERVER)


### PR DESCRIPTION
May help #2824
分析原因： 很可能是因为使用了 IllegalStateException ，导致无法正常进入QQAndroidNBot.kt下的
cause is NetworkException && cause.recoverable 分支，因为IllegalStateException不是NetworkException，直接走了else-> 把bot给manual closed了
```
            StateChangedObserver("BotOfflineEventBroadcasterAfter", State.OK, State.CLOSED) { new ->
                // logging performed by BotOfflineEventMonitor
                val cause = new.getCause()
                when {
                    cause is ForceOfflineException -> {
                        eventDispatcher.broadcastAsync(BotOfflineEvent.Force(bot, cause.title, cause.message))
                    }

                    cause is StatSvc.ReqMSFOffline.MsfOfflineToken -> {
                        eventDispatcher.broadcastAsync(BotOfflineEvent.MsfOffline(bot, cause))
                    }

                    cause is NetworkException && cause.recoverable -> {
                        eventDispatcher.broadcastAsync(BotOfflineEvent.Dropped(bot, cause))
                    }

                    cause is BotClosedByEvent -> {
                    }

                    else -> {
                        // any other unexpected exceptions considered as an error

                        // When bot is closed, eventDispatcher.isActive will be false.
                        // While in TestEventDispatcherImpl, eventDispatcher.isActive will always be true to enable catching the event.
                        if (eventDispatcher.isActive) {
                            eventDispatcher.broadcastAsync { BotOfflineEvent.Active(bot, cause) }
                        } else {
                            @OptIn(DelicateCoroutinesApi::class)
                            GlobalScope.launch {
                                BotOfflineEvent.Active(bot, cause).broadcast()
                            }
                        }
                    }
                }
            },
```