### PR TITLE
修复戳一戳 ，机器人误以为有人戳自己

### DIFF
--- a/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
@@ -337,7 +337,7 @@ internal class GroupNotificationProcessor(
                     return if (this == bot.id.toString()) {
                         group.botAsMember
                     } else {
-                        this.findMember()?: this.findFriendOrStranger()
+                        this.findMember() ?: this.findFriendOrStranger()
                     }
                 }
                 

--- a/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
@@ -327,19 +327,20 @@ internal class GroupNotificationProcessor(
         data: MsgType0x2DC,
     ) = data.context {
 
-        fun String.findUser(): UserOrBot? {
-            return if (this == bot.id.toString()) {
-                bot
-            } else {
-                this.findMember() ?: this.findFriendOrStranger()
-            }
-        }
-
         val grayTip = buf.loadAs(TroopTips0x857.NotifyMsgBody.serializer(), 1).optGeneralGrayTip
         markAsConsumed()
         when (grayTip?.templId) {
             // 群戳一戳
             10043L, 1133L, 1132L, 1134L, 1135L, 1136L -> {
+                
+                fun String.findUser(): UserOrBot? {
+                    return if (this == bot.id.toString()) {
+                        group.botAsMember
+                    } else {
+                        this.findMember()?: this.findFriendOrStranger()
+                    }
+                }
+                
                 // group nudge
                 // 预置数据，服务器将不会提供己方已知消息
                 val action = grayTip.msgTemplParam["action_str"].orEmpty()

--- a/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
@@ -331,7 +331,7 @@ internal class GroupNotificationProcessor(
             return if (this == bot.id.toString()) {
                 bot
             } else {
-                this.findMember()?: this.findFriendOrStranger()
+                this.findMember() ?: this.findFriendOrStranger()
             }
         }
 

--- a/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
+++ b/mirai-core/src/commonMain/kotlin/network/notice/group/GroupNotificationProcessor.kt
@@ -351,12 +351,12 @@ internal class GroupNotificationProcessor(
                 val fromUser = from?.findUser()
                 val targetUser = target?.findUser()
 
-                if(fromUser == null || targetUser == null){
+                if (fromUser == null || targetUser == null) {
                     markNotConsumed()
                     logger.debug {
                         "Cannot find from or target in Transformers528 0x14 template\ntemplId=${grayTip.templId}\nPermList=${grayTip.msgTemplParam.structureToString()}"
                     }
-                }else{
+                } else {
                     collected += NudgeEvent(
                             from = fromUser,
                             target = targetUser,


### PR DESCRIPTION
如果按群成员，即`Memebr`找，因为众所周知的原因它并不能总是成功，那么我于是定义了一个`findUser`函数，它应该优先`findMember`，然后`findFriendOrStranger`（容错）
因为如果按原来的逻辑，findMember失败后，很有可能就把戳的对象当成了自己了（后面的”?:“导致默认为自己哦！）

```
PS：我现在群里一堆Mirai机器人，戳某个特定的人的时候，这些机器人tm的一呼百应，肯定是这里出了问题
PS：代码格式。。应该没问题吧，我瞅了好多次了（心虚）
PS：自己实现了`findUser`似乎不够优雅，违反了kotlin的美学？但是有更好的方法吗，我不是特别懂，请赐教！
PS：我把缺省值默认为bot这个逻辑干掉了，很容易让bot以为在戳自己，导致意料之外的事情发生，不如发个log更实惠!
```